### PR TITLE
Update examples to use correct version of deps

### DIFF
--- a/examples/pipe/deps.edn
+++ b/examples/pipe/deps.edn
@@ -1,5 +1,5 @@
 {:deps
- {fundingcircle/jackdaw {:mvn/version "0.4.0-SNAPSHOT"}
+ {fundingcircle/jackdaw {:mvn/version "0.4.0"}
   org.apache.kafka/kafka-streams {:mvn/version "2.0.0"}
   org.apache.kafka/kafka-streams-test-utils {:mvn/version "2.0.0"}
   org.clojure/clojure {:mvn/version "1.9.0"}

--- a/examples/simple-ledger/deps.edn
+++ b/examples/simple-ledger/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {danlentz/clj-uuid {:mvn/version "0.1.7"}
-  fundingcircle/jackdaw {:mvn/version "0.4.0-SNAPSHOT"}
+  fundingcircle/jackdaw {:mvn/version "0.4.0"}
   org.apache.kafka/kafka-streams {:mvn/version "2.0.0"}
   org.apache.kafka/kafka-streams-test-utils {:mvn/version "2.0.0"}
   org.clojure/clojure {:mvn/version "1.9.0"}

--- a/examples/word-count/deps.edn
+++ b/examples/word-count/deps.edn
@@ -1,5 +1,5 @@
 {:deps
- {fundingcircle/jackdaw {:mvn/version "0.4.0-SNAPSHOT"}
+ {fundingcircle/jackdaw {:mvn/version "0.4.0"}
   org.apache.kafka/kafka-streams {:mvn/version "2.0.0"}
   org.apache.kafka/kafka-streams-test-utils {:mvn/version "2.0.0"}
   org.clojure/clojure {:mvn/version "1.9.0"}


### PR DESCRIPTION
Currently the examples deps.edn have jackdaw using `"0.4.0-SNAPSHOT"` they should use `"0.4.0"`.