### PR TITLE
correct kstream->ktable left-join fn args

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -57,8 +57,8 @@
   key."
   ([kstream ktable value-joiner-fn]
    (p/left-join kstream ktable value-joiner-fn))
-  ([kstream ktable value-joiner-fn topic-config]
-   (p/left-join kstream ktable value-joiner-fn topic-config)))
+  ([kstream ktable value-joiner-fn this-topic-config other-topic-config]
+   (p/left-join kstream ktable value-joiner-fn this-topic-config other-topic-config)))
 
 (defn filter
   [kstream predicate-fn]

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -79,10 +79,10 @@
      (left-join kstream ktable value-joiner-fn)))
 
   (left-join
-  [_ ktable value-joiner-fn topic-config]
+  [_ ktable value-joiner-fn topic-config other-topic-config]
   (configured-kstream
     config
-    (left-join kstream ktable value-joiner-fn topic-config)))
+    (left-join kstream ktable value-joiner-fn topic-config other-topic-config)))
 
   (filter
     [_ predicate-fn]

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -125,13 +125,14 @@
                 (value-joiner value-joiner-fn))))
 
   (left-join
-    [_ ktable value-joiner-fn {:keys [key-serde value-serde]}]
+    [_ ktable value-joiner-fn
+     {key-serde :key-serde this-value-serde :value-serde}
+     {other-value-serde :value-serde}]
     (clj-kstream
      (.leftJoin kstream
                 ^KTable (ktable* ktable)
                 ^ValueJoiner (value-joiner value-joiner-fn)
-                ^Serde key-serde
-                ^Serde value-serde)))
+                (Joined/with key-serde this-value-serde other-value-serde))))
 
   (peek
     [_ peek-fn]

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -37,7 +37,7 @@
   "Methods common to KStream and KTable."
   (left-join
     [kstream-or-ktable ktable value-joiner-fn]
-    [kstream-or-ktable ktable value-joiner-fn topic-config]
+    [kstream-or-ktable ktable value-joiner-fn this-topic-config other-topic-config]
     "Creates a KStream from the result of calling `value-joiner-fn` with
     each element in the KStream and the value in the KTable with the same
     key.")

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -87,7 +87,8 @@
         :args (s/cat :kstream-or-ktable ::kstream-or-ktable
                      :ktable ktable?
                      :value-joiner-fn ifn?
-                     :topic-config (s/? ::topic-config))
+                     :this-topic-config (s/? ::topic-config)
+                     :other-topic-config (s/? ::topic-config))
         :ret ::kstream-or-ktable)
 
 (s/fdef k/for-each!

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -75,6 +75,26 @@
 
           (let [keyvals (mock/get-keyvals driver topic-c)]
             (is (= [1 2] (first keyvals)))
+            (is (= [1 3] (second keyvals)))))))
+
+
+    (let [topic-a (mock/topic "topic-a")
+          topic-b (mock/topic "topic-b")
+          topic-c (mock/topic "topic-c")]
+
+      (with-open [driver (mock/build-driver (fn [builder]
+                                              (let [left (k/kstream builder topic-a)
+                                                    right (k/ktable builder topic-b)]
+                                                (k/to (k/left-join left right safe-add topic-a topic-b) topic-c))))]
+        (let [publish-left (partial mock/publish driver topic-a)
+              publish-right (partial mock/publish driver topic-b)]
+
+          (publish-left 1 2)
+          (publish-right 1 1)
+          (publish-left 1 2)
+
+          (let [keyvals (mock/get-keyvals driver topic-c)]
+            (is (= [1 2] (first keyvals)))
             (is (= [1 3] (second keyvals))))))))
 
   (testing "for-each!"


### PR DESCRIPTION
Corrects the kstream->ktable left-join fn arity which accepts the serdes, as the [contract](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KStream.html#leftJoin-org.apache.kafka.streams.kstream.KTable-org.apache.kafka.streams.kstream.ValueJoiner-org.apache.kafka.streams.kstream.Joined-) now requires a `Joined` instance