### PR TITLE
Make EDN serde configurable

### DIFF
--- a/src/jackdaw/serdes/edn.clj
+++ b/src/jackdaw/serdes/edn.clj
@@ -27,12 +27,15 @@
 
 (defn deserializer
   "Returns an EDN deserializer."
-  []
-  (jsfn/new-deserializer {:deserialize (fn [_ _ data]
-                                         (-> (from-bytes data)
-                                             clojure.edn/read-string))}))
+  ([]
+   (deserializer {}))
+  ([opts]
+   (let [opts (into {} opts)]
+     (jsfn/new-deserializer {:deserialize (fn [_ _ data]
+                                            (->> (from-bytes data)
+                                                 (clojure.edn/read-string opts)))}))))
 
 (defn serde
   "Returns an EDN serde."
-  []
-  (Serdes/serdeFrom (serializer) (deserializer)))
+  [& [opts]]
+  (Serdes/serdeFrom (serializer) (deserializer opts)))


### PR DESCRIPTION
Hello, 

I would like to use custom EDN readers with the EDN serde. This patch allows passing options to `edn/read-string` and make this configurable.

Would you like to merge this?

Thanks, r0man.