### PR TITLE
Introduce `suppress` to streams.

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -238,6 +238,11 @@
   ([ktable key-value-mapper-fn]
    (p/to-kstream ktable key-value-mapper-fn)))
 
+(defn suppress
+  "Suppress some updates from this changelog stream"
+  [ktable suppressed]
+  (p/suppress ktable suppressed))
+
 (defn ktable*
   "Returns the underlying KTable object."
   [ktable]

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -348,6 +348,12 @@
      config
      (outer-join ktable other-ktable value-joiner-fn)))
 
+  (suppress
+    [_ suppressed]
+    (configured-ktable
+     config
+     (suppress ktable suppressed)))
+
   (to-kstream
     [_]
     (configured-kstream

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -192,6 +192,14 @@
     [ktable key-value-mapper-fn]
     "Converts a KTable to a KStream.")
 
+  (suppress
+    [ktable {:keys [max-records max-bytes until-time-limit-ms]}]
+    "Suppress some updates from this changelog stream.
+    You can either specify `max-records` or `max-bytes`. If an empty map is
+    passed, the suppress will be unbounded. If `until-time-limit-ms` is set,
+    this will override the `TimeWindow` interval. Note that when relying on the
+    configured `TimeWindow` the default `grace` period is `24h - window-size`.")
+
   (ktable*
     [ktable]
     "Returns the underlying KTable object."))

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -42,6 +42,12 @@
 (def streams-builder?
   (partial satisfies? IStreamsBuilder))
 
+(s/def ::max-records int?)
+(s/def ::max-bytes int?)
+(s/def ::until-time-limit-ms int?)
+(s/def ::suppress-config (s/keys :opt-un [::max-records
+                                          ::max-bytes
+                                          ::until-time-limit-ms]))
 (s/def ::topic-name string?)
 (s/def ::key-serde any?)
 (s/def ::value-serde any?)
@@ -256,6 +262,11 @@
                      :other-ktable ktable?
                      :value-joiner-fn ifn?)
         :ret ktable?)
+
+(s/fdef k/suppress
+  :args (s/cat :ktable ktable?
+               :suppress ::suppress-config)
+  :ret ktable?)
 
 (s/fdef k/to-kstream
         :args (s/cat :ktable ktable?


### PR DESCRIPTION
Version 2.1 introduced a new operator: [suppress](https://kafka.apache.org/21/documentation/streams/developer-guide/dsl-api.html#window-final-results). It allows to only
forward the final result of a windowed aggregation.

This PR adds the `suppress` function to the streams namespace and
allows for the new operator to be used in Kafka Streams apps. It works but may not be in a final stage. Asking for feedback at this point whether this is what you have in mind or I should change something.

Best
Daniel