### PR TITLE
Alter EDN serde test to use 100 random chars and not any-printable

### DIFF
--- a/test/jackdaw/serdes/edn_test.clj
+++ b/test/jackdaw/serdes/edn_test.clj
@@ -21,7 +21,7 @@
                          (.serialize (jse/serializer) nil)))))))))
 
 (defspec edn-print-length-test 20
- (testing "EDN data is the same after serialization and deserialization with *print-length*."
+  (testing "EDN data is the same after serialization and deserialization with *print-length*."
     (binding [*print-length* 100]
       (prop/for-all [x (gen/vector gen/int (inc *print-length*))]
         (is (= x (->> (.serialize (jse/serializer) nil x)

--- a/test/jackdaw/serdes/edn_test.clj
+++ b/test/jackdaw/serdes/edn_test.clj
@@ -8,20 +8,20 @@
 
 (defspec edn-roundtrip-test 20
   (testing "EDN data is the same after serialization and deserialization."
-    (prop/for-all [x gen/any-printable]
+    (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]
       (is (= x (->> (.serialize (jse/serializer) nil x)
                     (.deserialize (jse/deserializer) nil)))))))
 
 (defspec edn-reverse-roundtrip-test 20
   (testing "EDN data is the same after deserialization and serialization."
-    (prop/for-all [x gen/any-printable]
+    (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]
       (let [bytes (.serialize (jse/serializer) nil x)]
         (is (= (seq bytes)
                (seq (->> (.deserialize (jse/deserializer) nil bytes)
                          (.serialize (jse/serializer) nil)))))))))
 
 (defspec edn-print-length-test 20
-  (testing "EDN data is the same after serialization and deserialization with *print-length*."
+ (testing "EDN data is the same after serialization and deserialization with *print-length*."
     (binding [*print-length* 100]
       (prop/for-all [x (gen/vector gen/int (inc *print-length*))]
         (is (= x (->> (.serialize (jse/serializer) nil x)


### PR DESCRIPTION
`gen/any-printable` would sometimes return `Double/NaN`, which is never equal to itself, causing the round trip equality test to fail.

Fixes issue #26 

=> (= ##NaN ##NaN)
false
=> (= Double/NaN Double/NaN)
false

&c.