### PR TITLE
Use docker for external services in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ references:
           SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:2181
           SCHEMA_REGISTRY_HOST_NAME: localhost
           SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
-      - image: confluentinc/cp-rest-proxy:5.1.0
+      - image: confluentinc/cp-kafka-rest:5.1.0
         environment:
           KAFKA_REST_ZOOKEEPER_CONNECT: localhost:2181
           KAFKA_REST_LISTENERS: http://0.0.0.0:8082

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,12 @@ references:
           SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:2181
           SCHEMA_REGISTRY_HOST_NAME: localhost
           SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
+      - image: confluentinc/cp-rest-proxy:5.1.0
+        environment:
+          KAFKA_REST_ZOOKEEPER_CONNECT: localhost:2181
+          KAFKA_REST_LISTENERS: http://0.0.0.0:8082
+          KAFKA_REST_SCHEMA_REGISTRY: http://localhost:8081
+          KAFKA_REST_HOST_NAME: localhost
     working_directory: ~/jackdaw
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           key: *mvn_cache_key
           paths:
             - /home/circleci/.m2
-  test:
+  build:
     <<: *test_config
     steps:
       - *restore_repo
@@ -93,14 +93,14 @@ jobs:
 
 workflows:
   version: 2
-  test:
+  build_and_deploy:
     jobs:
       - checkout_code
       - deps:
           context: org-global
           requires:
             - checkout_code
-      - test:
+      - build:
           context: org-global
           requires:
             - deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,11 @@ references:
         - *mvn_cache_key
         - *mvn_cache_backup
 
+  build_config: &build_config
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+    working_directory: ~/jackdaw
+
   test_config: &test_config
     docker:
       - image: circleci/clojure:lein-2.8.1
@@ -51,7 +56,7 @@ references:
 
 jobs:
   checkout_code:
-    <<: *test_config
+    <<: *build_config
     steps:
       - *restore_repo
       - checkout
@@ -60,7 +65,7 @@ jobs:
           paths:
             - .
   deps:
-    <<: *test_config
+    <<: *build_config
     steps:
       - *restore_repo
       - *restore_mvn
@@ -70,7 +75,6 @@ jobs:
           key: *mvn_cache_key
           paths:
             - /home/circleci/.m2
-
   test:
     <<: *test_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,40 +1,91 @@
 ---
 version: 2
 
-jobs:
-  build:
+references:
+  repo_cache_key: &repo_cache_key
+    v1-jackdaw-{{ .Branch }}-{{ .Revision }}
+
+  repo_cache_backup_1: &repo_cache_backup_1
+    v1-jackdaw-{{ .Branch }}
+
+  repo_cache_backup_2: &repo_cache_backup_2
+    v1-jackdaw
+
+  restore_repo: &restore_repo
+    restore_cache:
+      keys:
+        - *repo_cache_key
+        - *repo_cache_backup_1
+        - *repo_cache_backup_2
+
+  mvn_cache_key: &mvn_cache_key
+    v1-jackdaw-deps-{{ checksum "project.clj" }}
+
+  mvn_cache_backup: &mvn_cache_backup
+    v1-jackdaw-deps
+
+  restore_mvn: &restore_mvn
+    restore_cache:
+      keys:
+        - *mvn_cache_key
+        - *mvn_cache_backup
+
+  test_config: &test_config
     docker:
       - image: circleci/clojure:lein-2.8.1
-    environment:
-      _JAVA_OPTIONS: "-Xms1024m -Xmx3072m"
-    steps:
-      - checkout
-      - run: wget -qO - https://packages.confluent.io/deb/4.0/archive.key | sudo apt-key add -
-      - run: sudo apt-get install software-properties-common apt-transport-https less
-      - run: sudo add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/4.0 stable main"
-      - run: sudo apt-get update && sudo apt-get install confluent-platform-oss-2.11
-      - run: sudo sed -i 's/\(log.retention.check.interval.ms\)=.*$/\1=2000/' /etc/kafka/server.properties
+      - image: confluentinc/cp-zookeeper:4.0.2-2
+        environment:
+          ZOOKEEPER_CLIENT_PORT: 2181
+      - image: confluentinc/cp-kafka:4.0.2-2
+        environment:
+          KAFKA_BROKER_ID: 1
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+    working_directory: ~/jackdaw
 
-      - &restore-cache
-        restore_cache:
-          keys:
-            - libs-cache-{{ checksum "project.clj" }}-{{ checksum ".circleci/config.yml" }}
-            - libs-cache-{{ checksum "project.clj" }}
-            - libs-cache-
-      - run:
-          command: nohup confluent start
-      - run:
-          command: confluent status
+jobs:
+  checkout_code:
+    <<: *test_config
+    steps:
+      - *restore_repo
+      - checkout
       - save_cache:
-          key: libs-cache-{{ checksum "project.clj" }}-{{ checksum ".circleci/config.yml" }}
+          key: v1-jackdaw-{{ .Branch }}-{{ .Revision }}
           paths:
-            - ~/.m2/
+            - .
+  deps:
+    <<: *test_config
+    steps:
+      - *restore_repo
+      - *restore_mvn
       - run:
-          command: lein test
+          lein with-profiles +test deps
+      - save_cache:
+          key: *mvn_cache_key
+          paths:
+            - /home/circleci/.m2
+
+  test:
+    <<: *test_config
+    steps:
+      - *restore_repo
+      - *restore_mvn
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          lein test
 
 workflows:
   version: 2
-  build_and_deploy:
+  test:
     jobs:
-      - build:
+      - checkout_code
+      - deps:
           context: org-global
+          requires:
+            - checkout_code
+      - test:
+          context: org-global
+          requires:
+            - deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,15 +33,20 @@ references:
   test_config: &test_config
     docker:
       - image: circleci/clojure:lein-2.8.1
-      - image: confluentinc/cp-zookeeper:4.0.2-2
+      - image: confluentinc/cp-zookeeper:5.1.0
         environment:
           ZOOKEEPER_CLIENT_PORT: 2181
-      - image: confluentinc/cp-kafka:4.0.2-2
+      - image: confluentinc/cp-kafka:5.1.0
         environment:
           KAFKA_BROKER_ID: 1
           KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
           KAFKA_ZOOKEEPER_CONNECT: localhost:2181
+      - image: confluentinc/cp-schema-registry:5.1.0
+        environment:
+          SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: localhost:2181
+          SCHEMA_REGISTRY_HOST_NAME: localhost
+          SCHEMA_REGISTRY_LISTENERS: http://localhost:8081
     working_directory: ~/jackdaw
 
 jobs:


### PR DESCRIPTION
The existing circleci configuration must tweak the apt settings on the test runner before installing the confluent tools and running them as a separate process alongside the test. CircleCI allows for secondary images to be run alongside the primary test image for the purpose of providing external services required by a test suite. This PR makes the required services available by getting circleci to launch the secondary images meaning the main build/test tasks can focus on downloading and caching dependencies and then simply running the test.

Structuring the config in this way also makes it more manageable to test against multiple versions of kafka. For example, we could test against prior versions with something like this...