### PR TITLE
Miscellaneous fixes/consistency changes

### DIFF
--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -136,10 +136,11 @@
   current value."
   [^AdminClient client topics]
   {:pre [(client? client)
-          (sequential? topics)]}
+         (sequential? topics)]}
   (->> @(describe-configs* client (map #(-> % :topic-name jd/->topic-resource) topics))
+       (into {})
        (reduce-kv (fn [m k v]
-                   (assoc m (jd/datafy k) (jd/datafy v)))
+                    (assoc m (jd/datafy k) (jd/datafy v)))
                   {})))
 
 (defn topics-ready?

--- a/src/jackdaw/client.clj
+++ b/src/jackdaw/client.clj
@@ -267,7 +267,8 @@
 
   Returns the consumer for convenience with `->`, `doto` etc."
   [^Consumer consumer timestamp topics]
-  (let [topic-partitions (mapcat #(partitions-for consumer %) topics)
+  (let [topic-partitions (->> (mapcat #(partitions-for consumer %) topics)
+                              (map #(select-keys % [:topic-name :partition])))
         start-offsets (offsets-for-times consumer
                                          (zipmap topic-partitions
                                                  (repeat timestamp)))]

--- a/src/jackdaw/client.clj
+++ b/src/jackdaw/client.clj
@@ -267,8 +267,7 @@
 
   Returns the consumer for convenience with `->`, `doto` etc."
   [^Consumer consumer timestamp topics]
-  (let [topic-partitions (->> (mapcat #(partitions-for consumer %) topics)
-                              (map #(select-keys % [:topic-name :partition])))
+  (let [topic-partitions (mapcat #(partitions-for consumer %) topics)
         start-offsets (offsets-for-times consumer
                                          (zipmap topic-partitions
                                                  (repeat timestamp)))]

--- a/src/jackdaw/client/log.clj
+++ b/src/jackdaw/client/log.clj
@@ -58,6 +58,6 @@
 (defn count-messages
   "Consumes all of the messages on a topic to determine the current count"
   [config topic]
-  (with-open [^Consumer consumer (-> (jc/subscribed-consumer config topic)
+  (with-open [^Consumer consumer (-> (jc/subscribed-consumer config [topic])
                                      (jc/seek-to-beginning-eager))]
     (count (log-until-inactivity consumer 2000))))

--- a/src/jackdaw/client/partitioning.clj
+++ b/src/jackdaw/client/partitioning.clj
@@ -79,16 +79,16 @@
 
   See `#'record-key->key-fn` for an example of annotating a topic with
   a `key-fn` function."
-  ([^Producer producer {:keys [topic-name ::key-fn] :as t} value]
+  ([^Producer producer {:keys [key-fn] :as t} value]
    (if key-fn
      (->ProducerRecord producer t (key-fn value) value)
-     (jd/->ProducerRecord ^String topic-name value)))
-  ([^Producer producer {:keys [topic-name ::partition-fn] :as t} key value]
+     (jd/->ProducerRecord t value)))
+  ([^Producer producer {:keys [partition-fn] :as t} key value]
    (if partition-fn
      (as-> (jc/num-partitions producer t) %
        (partition-fn t key value %)
        (->ProducerRecord producer t % key value))
-     (jd/->ProducerRecord ^String topic-name key value)))
+     (jd/->ProducerRecord t key value)))
   ([^Producer producer topic partition key value]
    (jd/->ProducerRecord topic (int partition) key value))
   ([^Producer producer topic partition timestamp key value]

--- a/src/jackdaw/data/admin.clj
+++ b/src/jackdaw/data/admin.clj
@@ -7,9 +7,11 @@
 ;;; ConfigEntry
 
 (defn ->ConfigEntry
-  ""
-  ^ConfigEntry [^String k ^String v]
-  (ConfigEntry. k v))
+  "value can be a string else is a map where value is the :value key"
+  ^ConfigEntry [^String k v]
+  (if (string? v)
+    (ConfigEntry. k v)
+    (ConfigEntry. k (:value v))))
 
 (defn->data ConfigEntry->data
   ""

--- a/src/jackdaw/data/common.clj
+++ b/src/jackdaw/data/common.clj
@@ -36,18 +36,6 @@
    :partition (.partition tpi)
    :replicas (mapv datafy (.replicas tpi))})
 
-;;; PartitionInfo
-
-(defn->data PartitionInfo->data
-  ""
-  [^PartitionInfo pi]
-  {:topic-name (.topic pi)
-   :isr (mapv datafy (.inSyncReplicas pi))
-   :leader (datafy (.leader pi))
-   :partition (.partition pi)
-   :replicas (mapv datafy (.replicas pi))
-   :offline-replicas (mapv datafy (.offlineReplicas pi))})
-
 ;;; Topic partition tuples
 
 (defn ^TopicPartition ->TopicPartition

--- a/src/jackdaw/data/common.clj
+++ b/src/jackdaw/data/common.clj
@@ -4,6 +4,7 @@
           PartitionInfo
           Node TopicPartition TopicPartitionInfo])
 
+
 ;;; Node
 
 (defn->data Node->data
@@ -35,6 +36,18 @@
    :partition (.partition tpi)
    :replicas (mapv datafy (.replicas tpi))})
 
+;;; PartitionInfo
+
+(defn->data PartitionInfo->data
+  ""
+  [^PartitionInfo pi]
+  {:topic-name (.topic pi)
+   :isr (mapv datafy (.inSyncReplicas pi))
+   :leader (datafy (.leader pi))
+   :partition (.partition pi)
+   :replicas (mapv datafy (.replicas pi))
+   :offline-replicas (mapv datafy (.offlineReplicas pi))})
+
 ;;; Topic partition tuples
 
 (defn ^TopicPartition ->TopicPartition
@@ -46,8 +59,8 @@
   "Given a `::topic-parititon`, build an equivalent `TopicPartition`.
 
   Inverts `(datafy ^TopicPartition tp)`."
-  [{:keys [:topic-name
-           :partition]
+  [{:keys [topic-name
+           partition]
     :as m}]
   (->TopicPartition m partition))
 
@@ -75,5 +88,6 @@
   (->TopicPartition {:topic-name "foo"} 1)
   (TopicPartition->data *1)
   (map->TopicPartition *1)
+
   ;; On 1.10+
   (datafy *1))

--- a/src/jackdaw/data/producer.clj
+++ b/src/jackdaw/data/producer.clj
@@ -12,20 +12,20 @@
 
 (defn ^ProducerRecord ->ProducerRecord
   "Given unrolled ctor-style arguments creates a Kafka `ProducerRecord`."
-  ([{:keys [:topic-name]} value]
+  ([{:keys [topic-name]} value]
    (ProducerRecord. ^String topic-name value))
-  ([{:keys [:topic-name]} key value]
+  ([{:keys [topic-name]} key value]
    (ProducerRecord. ^String topic-name key value))
-  ([{:keys [:topic-name]} partition key value]
+  ([{:keys [topic-name]} partition key value]
    (ProducerRecord. ^String topic-name
                     ^Integer (int partition)
                     key value))
-  ([{:keys [:topic-name]} partition timestamp key value]
+  ([{:keys [topic-name]} partition timestamp key value]
    (ProducerRecord. ^String topic-name
                     ^Integer (int partition)
                     ^Long (long timestamp)
                     key value))
-  ([{:keys [:topic-name]} partition timestamp key value headers]
+  ([{:keys [topic-name]} partition timestamp key value headers]
    (ProducerRecord. ^String topic-name
                     ^Integer (int partition)
                     ^Long (long timestamp)

--- a/src/jackdaw/streams/extras.clj
+++ b/src/jackdaw/streams/extras.clj
@@ -67,12 +67,12 @@
    `(let [t# ~topic]
       (-> ~builder
           (map-validating! t# ~topic-spec ~(with-file (meta &form)))
-          (js/to! t#))))
+          (js/to t#))))
   ([builder partition-fn topic topic-spec]
    `(let [t# ~topic]
       (-> ~builder
           (map-validating! t# ~topic-spec ~(with-file (meta &form)))
-          (js/to! ~partition-fn t#)))))
+          (js/to ~partition-fn t#)))))
 
 (defmacro through
   "Wraps `#'jackdaw.streams/through`, providing validation of records


### PR DESCRIPTION
- Adds `(into {})` to describe-topics-configs because `AdminClient/describeConfigs` retunrs a java map not a clojure map.
- Fix call to `subscribed-consumer` that now expects an array of topics
- Fix `offsets-for-times` call expecting a map not a sequence
- Fix `seek-to-timestamp`
- Fix call in `partitioning/->ProducerRecord` to `jackdaw.data/->ProducerRecord` with invalid topic name parameter
- Fix `->ConfigEntry` that supports key -> value  and the datafied version of Config
- Add missing PartitionInfo->data 
- Fix calls to `js/to` that where called as `js/to!`
- Change some destructured key map arguments not have the colon before the key as is most common to use that syntax 