### PR TITLE
Add Confluent repository

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject fundingcircle/jackdaw "_"
   :description "A Clojure library for the Apache Kafka distributed streaming platform."
 
+  :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
+
   :dependencies [[aleph "0.4.6"]
                  [clj-time "0.15.1"]
                  [org.clojure/core.async "0.4.490"]


### PR DESCRIPTION
Jackdaw relies on artifacts which are available only on the Confluent repository.
Developers should not be expected to have the repo in their private leiningen profile.

Eg. after a fresh clone, doing a `lean pom && mvn dependency:tree` fails.