### PR TITLE
add left-join-example

### DIFF
--- a/examples/user-events-region/.gitignore
+++ b/examples/user-events-region/.gitignore
@@ -1,0 +1,15 @@
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/
+.idea
+*.iml
+.DS_Store

--- a/examples/user-events-region/README.md
+++ b/examples/user-events-region/README.md
@@ -1,0 +1,22 @@
+# user-events-region
+
+A Clojure library designed to ... well, that part is up to you.
+
+## Usage
+
+FIXME
+
+## License
+
+Copyright © 2019 FIXME
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License, v. 2.0 are satisfied: GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or (at your
+option) any later version, with the GNU Classpath Exception which is available
+at https://www.gnu.org/software/classpath/license.html.

--- a/examples/user-events-region/dev/system.clj
+++ b/examples/user-events-region/dev/system.clj
@@ -1,0 +1,66 @@
+(ns system
+  "Functions to start and stop the system, used for interactive
+  development.
+  The `system/start` and `system/stop` functions are required by the
+  `user` namespace and should not be called directly."
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [clojure.java.shell :refer [sh]]
+            [jackdaw.admin :as ja]
+            [user-events-region.core :as app]))
+
+(def system nil)
+
+(defn kafka-admin-client-config
+  []
+  {"bootstrap.servers" "localhost:9092"})
+
+(defn create-topics
+  "Takes a list of topics and creates these using the names given."
+  [topic-config-list]
+  (with-open [client (ja/->AdminClient (kafka-admin-client-config))]
+    (ja/create-topics! client topic-config-list)))
+
+(defn re-delete-topics
+  "Takes an instance of java.util.regex.Pattern and deletes any Kafka
+  topics that match."
+  [re]
+  (with-open [client (ja/->AdminClient (kafka-admin-client-config))]
+    (let [topics-to-delete (->> (ja/list-topics client)
+                                (filter #(re-find re (:topic-name %))))]
+      (ja/delete-topics! client topics-to-delete))))
+
+(defn application-id
+  "Takes an application config and returns an `application.id`."
+  [app-config]
+  (get app-config "application.id"))
+
+(defn destroy-state-stores
+  "Takes an application config and deletes local files associated with
+  internal state."
+  [app-config]
+  (sh "rm" "-rf" (str "/tmp/kafka-streams/" (application-id app-config)))
+  (log/info "internal state is deleted"))
+
+(defn stop
+  "Stops the app, and deletes topics and internal state.
+  This functions is required by the `user` namespace and should not
+  be called directly."
+  []
+  (when system
+    (app/stop-app (:app system)))
+  (re-delete-topics (re-pattern (str "("
+                                     (str/join "|" (app/topic-names))
+                                     "|"
+                                     (application-id (app/app-config))
+                                     ".*)")))
+  (destroy-state-stores (app/app-config)))
+
+(defn start
+  "Creates topics, and starts the app.
+  This functions is required by the `user` namespace and should not
+  be called directly."
+  []
+  (with-out-str (stop))
+  (create-topics (map app/topic-config (app/topic-names)))
+  {:app (app/start-app (app/app-config))})

--- a/examples/user-events-region/doc/intro.md
+++ b/examples/user-events-region/doc/intro.md
@@ -1,0 +1,3 @@
+# Introduction to user-events-region
+
+TODO: write [great documentation](http://jacobian.org/writing/what-to-write/)

--- a/examples/user-events-region/project.clj
+++ b/examples/user-events-region/project.clj
@@ -1,0 +1,15 @@
+(defproject user-events-region "0.1.0-SNAPSHOT"
+            :description "FIXME: write description"
+            :url "http://example.com/FIXME"
+            :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
+                      :url  "https://www.eclipse.org/legal/epl-2.0/"}
+            :dependencies [[fundingcircle/jackdaw "0.4.3"]
+                           [org.apache.kafka/kafka-streams "2.0.0"]
+                           [org.apache.kafka/kafka-streams-test-utils "2.0.0"]
+                           [org.clojure/clojure "1.9.0"]
+                           [org.clojure/tools.logging "0.3.1"]]
+            :target-path "target/%s"
+            :repositories [["confluent" "https://packages.confluent.io/maven/"]]
+            :source-paths ["src" "test" "resources" "dev" "../dev"]
+            :profiles {:uberjar {:aot :all}}
+            :repl-options {:init-ns user-events-region.core})

--- a/examples/user-events-region/src/user_events_region/core.clj
+++ b/examples/user-events-region/src/user_events_region/core.clj
@@ -1,0 +1,135 @@
+(ns user-events-region.core
+  "Demonstrates how to perform a join between a KStream and a KTable.
+
+   We join a stream of click events that reads from the click-events topic
+   and users table that reads from a topic named user-region to compute the
+   number of clicks per region."
+  (:gen-class)
+  (:require [clojure.string :as str]
+            [clojure.pprint :as pp]
+            [clojure.tools.logging :refer [info]]
+            [jackdaw.streams :as j]
+            [jackdaw.serdes.edn :as jse])
+  (:import [org.apache.kafka.common.serialization Serdes]))
+
+(defn app-config []
+  {"application.id"            "region-clicks"
+   "bootstrap.servers"         "localhost:9092"
+   "cache.max.bytes.buffering" "0"})
+
+(defn topic-names []
+  ["user-region" "click-events" "clicks-per-region"])
+
+(defn user-region-entries []
+  (vector ["alice" "asia"]
+          ["bob" "america"]
+          ["chao" "asia"]
+          ["alice" "europe"]
+          ["eve" "america"]
+          ["fang" "asia"]
+          ["gandalf" "europe"]
+          ["marina" "europe"]))
+
+(defn click-events-entries []
+  (vector ["gandalf" 254]
+          ["fang" 834]
+          ["chao" 550]
+          ["bob" 970]
+          ["alice" 69]
+          ["bob" 936]
+          ["bob" 675]))
+
+(defn topic-config
+  ([topic-name]
+   (topic-config topic-name (jse/serde) (jse/serde)))
+  ([topic-name key-serde value-serde]
+   {:topic-name         topic-name
+    :partition-count    1
+    :replication-factor 1
+    :topic-config       {}
+    :key-serde          key-serde
+    :value-serde        value-serde}))
+
+
+(defn topology-builder
+  [builder]
+  (let [user-region-table (j/ktable builder (topic-config "user-region"))
+
+        click-events-stream (j/kstream builder (topic-config "click-events"))
+
+        ;; perform a left-join on regions-table ("alice" "us") and click events ("alice" 200)
+        ;; and compute the number of clicks per region
+        clicks-region-counts (-> click-events-stream
+                                (j/left-join user-region-table
+                                             (fn [events region] (vector region events)))
+                                (j/map (fn [[_ v]] v))
+                                (j/group-by-key (topic-config nil (Serdes/String) (Serdes/Long)))
+
+                                ;; sums up the individual number of clicks by geo-region
+                                (j/reduce (fn [acc curr] (+ acc curr))
+                                          (topic-config "clicks-store")))]
+
+    (-> clicks-region-counts
+        (j/to-kstream)
+        (j/peek (fn [[k v]] (println (str {:key k :value v}))))
+        (j/to (topic-config "clicks-per-region")))
+    builder))
+
+(defn start-app
+  "Starts the stream processing application."
+  [app-config]
+  (let [builder (j/streams-builder)
+        topology (topology-builder builder)
+        app (j/kafka-streams topology app-config)]
+    (j/start app)
+    (info "Done")
+    app))
+
+(defn stop-app
+  "Stops the stream processing application."
+  [app]
+  (j/close app)
+  (info "Done"))
+
+(defn -main
+  "Starts the app"
+  [& args]
+  (start-app (app-config)))
+
+(comment
+  ;;; Start
+  ;;;
+
+  ;; Needed to invoke the forms from this namespace. When typing
+  ;; directly in the REPL, skip this step.
+  (require '[user :refer :all :exclude [topic-config]])
+
+
+  ;; Start ZooKeeper and Kafka.
+  ;; This requires the Confluent Platform CLI which may be obtained
+  ;; from `https://www.confluent.io/download/`. If ZooKeeper and Kafka
+  ;; are already running, skip this step.
+  (confluent/start)
+
+
+  ;; Create the `input` and `output` topics, and start the app.
+  (start)
+
+
+  ;; Get a list of current topics.
+  (list-topics)
+
+  (doseq [[key value] (user-region-entries)]
+    (publish (topic-config "user-region") key value))
+
+  (doseq [[key value] (click-events-entries)]
+    (publish (topic-config "click-events") key value))
+
+  (get-keyvals (topic-config "clicks-per-region"))
+  ;; You should see the value of America updated from
+  ;; ["america" 2581] to ["america" 7581]
+  (publish (topic-config "click-events") "bob" 5000)
+
+  (get-keyvals (topic-config "clicks-per-region"))
+
+  )

--- a/examples/user-events-region/test/user_events_region/core_test.clj
+++ b/examples/user-events-region/test/user_events_region/core_test.clj
@@ -1,0 +1,7 @@
+(ns user-events-region.core-test
+  (:require [clojure.test :refer :all]
+            [user-events-region.core :refer :all]))
+
+(deftest a-test
+  (testing "FIXME, I fail."
+    (is (= 0 1))))


### PR DESCRIPTION
We show an example of performing a left join op between a K-stream and K-table. More specifically we enrich an incoming stream of events with side data, and then compute aggregations based on the enriched stream.

Inspired by: https://www.confluent.io/blog/distributed-real-time-joins-and-aggregations-on-user-activity-events-using-kafka-streams/

Version not final, looking for initial feedback. Thanks! 🚀 