### PR TITLE
Fix release automation

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [org.clojure/core.cache "0.7.2"]]
 
   :aot [jackdaw.serdes.fn-impl]
+  :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 
   :git-version
   {:status-to-version
@@ -59,8 +60,7 @@
                              [org.apache.kafka/kafka-streams-test-utils "2.1.0"]
                              [org.clojure/test.check "0.9.0"]]
 
-              :plugins [[lein-codox "0.10.3"]
-                        [me.arrdem/lein-git-version "2.0.8"]]
+              :plugins [[lein-codox "0.10.3"]]
               :codox
               {:output-path "codox"
                :source-uri "http://github.com/fundingcircle/jackdaw/blob/{version}/{filepath}#L{line}"}}


### PR DESCRIPTION
The lein-git-version plugin is required in more than just the `:dev` profile. Lets reinstate it back at the top level for now and we can discuss where it should go.