### PR TITLE
Store test logs as artifacts in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,8 @@ jobs:
           docker_layer_caching: true
       - run:
           lein test
+      - store_artifacts:
+          path: ./logs
 
 workflows:
   version: 2


### PR DESCRIPTION
Now the test logs are going to a file, we can upload them to S3 and make them available as build artifacts with this one simple trick.