### PR TITLE
Use manifold for all async in the test-machine

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
 
   :dependencies [[aleph "0.4.6"]
                  [clj-time "0.15.1"]
-                 [org.clojure/core.async "0.4.490"]
                  [danlentz/clj-uuid "0.1.7"]
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -40,8 +40,8 @@
 ;;                ;;   )
 
 ;;   :exit-hooks  ;; []
-;;   :consumer    {:messages (async/chan)} source of test output
-;;   :producer    {:messages (async/chan)} sink for test-input
+;;   :consumer    {:messages (s/stream)} source of test output
+;;   :producer    {:messages (s/stream)} sink for test-input
 
 ;; The consumer and producer keys are themselves maps that each contains a
 ;; `:messages` channel used for kafka IO. `(get-in machine [:producer :messages])`

--- a/src/jackdaw/test/commands/write.clj
+++ b/src/jackdaw/test/commands/write.clj
@@ -1,6 +1,6 @@
 (ns jackdaw.test.commands.write
   (:require
-   [clojure.core.async :as async]
+   [manifold.stream :as s]
    [clojure.tools.logging :as log]
    [jackdaw.client.partitioning :as partitioning]))
 
@@ -54,7 +54,7 @@
            messages (:messages (:producer machine))
            ack (promise)]
        (log/info "Sending" to-send "to topic" topic-name)
-       (async/put! messages (assoc to-send :ack ack))
+       (s/put! messages (assoc to-send :ack ack))
        (deref ack (:timeout opts 1000) {:error :timeout}))
      {:error :unknown-topic
       :topic topic-name

--- a/src/jackdaw/test/transports/identity.clj
+++ b/src/jackdaw/test/transports/identity.clj
@@ -1,31 +1,33 @@
 (ns jackdaw.test.transports.identity
   (:require
    [clojure.tools.logging :as log]
-   [clojure.core.async :as async]
+   [manifold.stream :as s]
+   [manifold.deferred :as d]
    [jackdaw.test.journal :as j]
    [jackdaw.test.transports :as t]))
 
 (defn identity-consumer
-  [ch]
+  [stream]
   (let [started? (promise)]
     {:started? started?
-     :messages ch}))
+     :messages stream}))
 
 (defn identity-producer
   []
-  (let [messages (async/chan 1)]
+  (let [messages (s/stream 1)]
     {:messages messages}))
 
 (defmethod t/transport :identity
   [{:keys [topics]}]
-  (let [ch (async/chan 1)
+  (let [ch (s/stream 1)
         test-consumer (identity-consumer ch)
-        test-producer (identity-producer)
-        p (async/pipe (:messages test-producer)
-                      (:messages test-consumer))]
+        test-producer (identity-producer)]
+
+    (s/connect (:messages test-producer)
+               (:messages test-consumer))
+
     {:consumer test-consumer
      :producer test-producer
      :topics topics
      :exit-hooks [(fn []
-                    (async/close! (:messages test-producer))
-                    (async/<!! p))]}))
+                    (s/close! (:messages test-producer)))]}))

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -1,12 +1,13 @@
 (ns jackdaw.test.transports.mock
   (:require
    [clojure.tools.logging :as log]
-   [clojure.core.async :as async]
    [jackdaw.client :as kafka]
    [jackdaw.test.journal :as j]
    [jackdaw.test.transports :as t]
    [jackdaw.test.serde :refer [byte-array-serializer byte-array-deserializer
-                               apply-serializers apply-deserializers serde-map]])
+                               apply-serializers apply-deserializers serde-map]]
+   [manifold.stream :as s]
+   [manifold.deferred :as d])
   (:import
    (org.apache.kafka.common.record TimestampType)
    (org.apache.kafka.clients.consumer ConsumerRecord)))
@@ -78,52 +79,57 @@
                              (map :output))]
       (try
         (when-not (empty? topic-batches)
-          (async/onto-chan messages (apply concat topic-batches) false))
+          (s/put-all! messages (apply concat topic-batches)))
         (catch Throwable e
           (log/error (Throwable->map e))
-          (async/put! messages {:error e}))))))
+          (s/put! messages {:error e}))))))
 
 (defn mock-consumer
   [driver topic-config deserializers]
   (let [continue? (atom true)
-        messages  (async/chan 1 (comp
-                                 (map (with-output-record topic-config))
-                                 (map #(apply-deserializers deserializers %))))
+        messages  (s/stream 1 (comp
+                               (map (with-output-record topic-config))
+                               (map #(apply-deserializers deserializers %))))
 
         started?  (promise)
         poll      (poller messages topic-config)]
 
-    (log/infof "started mock consumer: %s" {:driver driver})
+    {:process (d/loop [cont? @continue?]
+                (d/chain cont? (fn [d]
+                                 (when-not (realized? started?)
+                                   (log/info "started mock consumer: %s" {:driver driver})
+                                   (deliver started? true))
 
-    {:process (async/go-loop []
-                (deliver started? true)
-                (if @continue?
-                  (do (poll driver)
-                      (Thread/sleep 100)
-                      (recur))
-                  (do (async/close! messages)
-                      (log/infof "stopped mock consumer: %s" {:driver driver}))))
+                                 (if @continue?
+                                   (d/future
+                                     (poll driver)
+                                     (Thread/sleep 100)
+                                     (d/recur @continue?))
+                                   (d/future
+                                     (s/close! messages)
+                                     (log/infof "stopped mock consumer: %s" {:driver driver}))))))
      :started? started?
      :messages messages
      :continue? continue?}))
 
 (defn mock-producer
   [driver topic-config serializers on-input]
-  (let [messages (async/chan 1 (comp
-                                (map #(apply-serializers serializers %))
-                                (map (with-input-record topic-config))))]
+  (let [messages (s/stream 1 (comp
+                              (map #(apply-serializers serializers %))
+                              (map (with-input-record topic-config))))]
 
     (log/infof "started mock producer: %s" {:driver driver})
 
-    (async/go-loop [{:keys [input-record ack] :as m} (async/<! messages)]
-      (if input-record
-        (do (on-input input-record)
-            (deliver ack {:topic (.topic input-record)
-                          :partition (.partition input-record)
-                          :offset (.offset input-record)})
-            (recur (async/<! messages)))
-        (log/infof "stopped mock producer: %s" {:driver driver})))
-
+    (d/loop [message (s/take! messages)]
+      (d/chain message
+               (fn [{:keys [input-record ack] :as message}]
+                 (if input-record
+                   (do (on-input input-record)
+                       (deliver ack {:topic (.topic input-record)
+                                     :partition (.partition input-record)
+                                     :offset (.offset input-record)})
+                       (d/recur (s/take! messages)))
+                   (log/infof "stopped mock producer: %s" {:driver driver})))))
     {:messages messages}))
 
 
@@ -141,6 +147,6 @@
      :serdes serdes
      :topics topics
      :exit-hooks [(fn []
-                    (async/close! (:messages test-producer))
+                    (s/close! (:messages test-producer))
                     (reset! (:continue? test-consumer) false)
-                    (async/<!! (:process test-consumer)))]}))
+                    @(:process test-consumer))]}))

--- a/test/jackdaw/test/transports/kafka_test.clj
+++ b/test/jackdaw/test/transports/kafka_test.clj
@@ -1,7 +1,6 @@
 (ns jackdaw.test.transports.kafka-test
   (:require
    [clojure.tools.logging :as log]
-   [clojure.core.async :as async]
    [clojure.test :refer :all]
    [jackdaw.streams :as k]
    [jackdaw.test :as jd.test]
@@ -10,7 +9,8 @@
    [jackdaw.test.serde :as serde]
    [jackdaw.test.transports :as trns]
    [jackdaw.test.transports.mock :as mock]
-   [jackdaw.test.transports.kafka])
+   [jackdaw.test.transports.kafka]
+   [manifold.stream :as s])
   (:import
    (java.util Properties)))
 
@@ -88,12 +88,12 @@
             msg-key (:id msg)]
 
         (log/info "feed: " msg)
-        (async/put! messages
-                    {:topic topic
-                     :key msg-key
-                     :value msg
-                     :timestamp (System/currentTimeMillis)
-                     :ack ack})
+        (s/put! messages
+                {:topic topic
+                 :key msg-key
+                 :value msg
+                 :timestamp (System/currentTimeMillis)
+                 :ack ack})
 
         (let [result (deref ack 1000 {:error :timeout})]
           (is (= "test-in" (:topic-name result)))
@@ -114,12 +114,12 @@
             msg-key (:id msg)]
 
         (log/info "feed: " msg)
-        (async/put! messages
-                    {:topic topic
-                     :key msg-key
-                     :value msg
-                     :timestamp (System/currentTimeMillis)
-                     :ack ack})
+        (s/put! messages
+                {:topic topic
+                 :key msg-key
+                 :value msg
+                 :timestamp (System/currentTimeMillis)
+                 :ack ack})
 
         (testing "the write is acknowledged"
           (let [result (deref ack 1000 {:error :timeout})]

--- a/test/jackdaw/test/transports/mock_test.clj
+++ b/test/jackdaw/test/transports/mock_test.clj
@@ -1,6 +1,5 @@
 (ns jackdaw.test.transports.mock-test
   (:require
-   [clojure.core.async :as async]
    [clojure.test :refer :all]
    [clojure.tools.logging :as log]
    [jackdaw.streams :as k]
@@ -8,7 +7,8 @@
    [jackdaw.test.transports.mock :as mock]
    [jackdaw.test :as jd.test]
    [jackdaw.test.transports :as trns]
-   [jackdaw.test.serde :as serde])
+   [jackdaw.test.serde :as serde]
+   [manifold.stream :as s])
   (:import
    (java.util Properties)
    (org.apache.kafka.streams TopologyTestDriver)))
@@ -80,12 +80,12 @@
             ack (promise)
             msg-key (:id msg)]
 
-        (async/put! messages
-                    {:topic topic
-                     :key msg-key
-                     :value msg
-                     :timestamp (System/currentTimeMillis)
-                     :ack ack})
+        (s/put! messages
+                {:topic topic
+                 :key msg-key
+                 :value msg
+                 :timestamp (System/currentTimeMillis)
+                 :ack ack})
 
         (let [result (deref ack 1000 {:error :timeout})]
           (is (= "test-in" (:topic result)))
@@ -102,12 +102,12 @@
             ack (promise)
             msg-key (:id msg)]
 
-        (async/put! messages
-                    {:topic topic
-                     :key msg-key
-                     :value msg
-                     :timestamp (System/currentTimeMillis)
-                     :ack ack})
+        (s/put! messages
+                {:topic topic
+                 :key msg-key
+                 :value msg
+                 :timestamp (System/currentTimeMillis)
+                 :ack ack})
 
         (testing "the write is acknowledged"
           (let [result (deref ack 1000 {:error :timeout})]
@@ -127,3 +127,4 @@
             (is (= "test-out" (:topic result)))
             (is (= 1 (:key result)))
             (is (= {:id 1 :payload "foo"} (:value result)))))))))
+

--- a/test/jackdaw/test/transports/rest_proxy_test.clj
+++ b/test/jackdaw/test/transports/rest_proxy_test.clj
@@ -2,7 +2,6 @@
   (:require
    [aleph.http :as http]
    [clojure.tools.logging :as log]
-   [clojure.core.async :as async]
    [clojure.test :refer :all]
    [jackdaw.streams :as k]
    [jackdaw.test :as jd.test]
@@ -10,7 +9,8 @@
    [jackdaw.test.serde :as serde]
    [jackdaw.test.journal :refer [with-journal watch-for]]
    [jackdaw.test.transports :as trns]
-   [jackdaw.test.transports.rest-proxy :as rest-proxy])
+   [jackdaw.test.transports.rest-proxy :as rest-proxy]
+   [manifold.stream :as s])
   (:import
    (java.util Properties)))
 
@@ -101,7 +101,7 @@
             msg-key (:id msg)]
 
         (log/info "feed: " msg)
-        (async/put! messages
+        (s/put! messages
                     {:topic topic
                      :key msg-key
                      :value msg
@@ -127,7 +127,7 @@
             msg-key (:id msg)]
 
         (log/info "feed: " msg)
-        (async/put! messages
+        (s/put! messages
                     {:topic topic
                      :key msg-key
                      :value msg


### PR DESCRIPTION
Replaces all use of core.async with the equivalent manifold construct. Basically, this means..

  - replacing `channel`s with `stream`s
  - replacing `go-loop`s with `d/loops`s
  - wrapping the bodies of the `go-loops` into `d/chain` handlers

This means we can remove the unnecessary dependency on core.async which can cause problems depending on the downstream application's other dependencies.

Also fixed a startup bug in the kstreams fixture that results in the possibility of tests being commenced without the app under test having reached the started state.