### PR TITLE
Add service-ready? fixture to block in tests until services are ready

### DIFF
--- a/test/jackdaw/serdes/avro/integration_test.clj
+++ b/test/jackdaw/serdes/avro/integration_test.clj
@@ -8,10 +8,14 @@
             [jackdaw.client.log :as jcl]
             [jackdaw.data :as jd]
             [jackdaw.serdes.avro :as avro]
-            [jackdaw.serdes.avro.schema-registry :as reg])
+            [jackdaw.serdes.avro.schema-registry :as reg]
+            [jackdaw.test.fixtures :as fix])
   (:import [org.apache.avro Schema$Parser]
            [org.apache.avro.generic GenericData$Record]
            [org.apache.kafka.common.serialization Serde Serdes]))
+
+(def +real-schema-registry-url+
+  "http://localhost:8081")
 
 (def +type-registry+
   (merge avro/+base-schema-type-registry+
@@ -22,7 +26,7 @@
    :avro/schema (slurp (io/resource "resources/example_schema.avsc"))})
 
 (def +real-schema-registry+
-  (let [url "http://localhost:8081"]
+  (let [url +real-schema-registry-url+]
     {:avro.schema-registry/url    url
      :avro.schema-registry/client (reg/client url 16)}))
 
@@ -43,16 +47,18 @@
           (is (= deserialized msg)))))))
 
 (deftest ^:integration real-schema-registry
-  (testing "schema registry set in config"
-    (let [serde ^Serde (avro/serde +type-registry+ +real-schema-registry+ +topic-config+)]
-      (let [msg {:customer-id (uuid/v4)
-                 :address     {:value    "foo"
-                               :key-path "foo.bar.baz"}}]
-        (let [serialized (-> (.serializer serde)
-                             (.serialize "foo" msg))
-              deserialized (-> (.deserializer serde)
-                               (.deserialize "foo" serialized))]
-          (is (= deserialized msg)))))))
+  (fix/with-fixtures [(fix/service-ready? {:http-url +real-schema-registry-url+
+                                           :http-timeout 5000})]
+    (testing "schema registry set in config"
+      (let [serde ^Serde (avro/serde +type-registry+ +real-schema-registry+ +topic-config+)]
+        (let [msg {:customer-id (uuid/v4)
+                   :address     {:value    "foo"
+                                 :key-path "foo.bar.baz"}}]
+          (let [serialized (-> (.serializer serde)
+                               (.serialize "foo" msg))
+                deserialized (-> (.deserializer serde)
+                                 (.deserialize "foo" serialized))]
+            (is (= deserialized msg))))))))
 
 ;;;; Client integration tests against real Kafka through a real topic
 
@@ -76,49 +82,51 @@
   (partial avro/serde +type-registry+ +real-schema-registry+))
 
 (deftest ^:integration schema-evolution-test
-  (testing "serialize then deserialize several serde versions"
-    (let [v1-cache
-          (atom (cache/lru-cache-factory {}))
+  (fix/with-fixtures [(fix/service-ready? {:http-url +real-schema-registry-url+
+                                           :http-timeout 5000})]
+    (testing "serialize then deserialize several serde versions"
+      (let [v1-cache
+            (atom (cache/lru-cache-factory {}))
 
-          test-topic-v1
-          {:topic-name
-           (str "test-topic-" (uuid/v4))
+            test-topic-v1
+            {:topic-name
+             (str "test-topic-" (uuid/v4))
 
-           :key-serde
-           (Serdes/String)
+             :key-serde
+             (Serdes/String)
 
-           :value-serde
-           (serde*
-            {:key?                false
-             :avro/schema         +test-schema-v1+
-             :avro/coercion-cache v1-cache})}
+             :value-serde
+             (serde*
+              {:key?                false
+               :avro/schema         +test-schema-v1+
+               :avro/coercion-cache v1-cache})}
 
-          test-topic-v2
-          (merge test-topic-v1
-                 {:value-serde
-                  (serde* {:key? false, :avro/schema +test-schema-v2+})})
+            test-topic-v2
+            (merge test-topic-v1
+                   {:value-serde
+                    (serde* {:key? false, :avro/schema +test-schema-v2+})})
 
-          test-topic-v3
-          (merge test-topic-v1
-                 {:value-serde
-                  (serde* {:key? false, :avro/schema +test-schema-v3+})})
+            test-topic-v3
+            (merge test-topic-v1
+                   {:value-serde
+                    (serde* {:key? false, :avro/schema +test-schema-v3+})})
 
-          topic+record
-          [[test-topic-v1 {:a "foo"}]
-           [test-topic-v2 {:a "foo", :b "bar"}]
-           [test-topic-v3 {:a "foo", :b "bar", :c (uuid/v4)}]]]
+            topic+record
+            [[test-topic-v1 {:a "foo"}]
+             [test-topic-v2 {:a "foo", :b "bar"}]
+             [test-topic-v3 {:a "foo", :b "bar", :c (uuid/v4)}]]]
 
-      (doseq [[t r] topic+record]
-        (with-open [p (jc/producer +local-kafka+ t)]
-          @(jc/send! p (jd/->ProducerRecord t 0 (:a r) r))))
+        (doseq [[t r] topic+record]
+          (with-open [p (jc/producer +local-kafka+ t)]
+            @(jc/send! p (jd/->ProducerRecord t 0 (:a r) r))))
 
-      (with-open [c (-> (jc/subscribed-consumer +local-kafka+ [test-topic-v1])
-                        (jc/seek-to-beginning-eager))]
-        (doseq [[[_ r] {r' :value}]
-                (map vector
-                     topic+record
-                     (doall (jcl/log-until-inactivity c 1000)))]
-          (is (= r r') "Record didn't round trip!")))
+        (with-open [c (-> (jc/subscribed-consumer +local-kafka+ [test-topic-v1])
+                          (jc/seek-to-beginning-eager))]
+          (doseq [[[_ r] {r' :value}]
+                  (map vector
+                       topic+record
+                       (doall (jcl/log-until-inactivity c 1000)))]
+            (is (= r r') "Record didn't round trip!")))
 
-      (is (= 3 (count (keys @v1-cache)))
-          "Expect this cache will have all three schema versions now"))))
+        (is (= 3 (count (keys @v1-cache)))
+            "Expect this cache will have all three schema versions now")))))


### PR DESCRIPTION
This might help with some of the intermittent test failures we see where it seems like the schema-registry is not up yet. Following this recommendation from the docker team....

    The best solution is to perform this check in your application code, both
    at startup and whenever a connection is lost for any reason.

Test-suites can quite reasonably be considered "your application" in this context
so this PR adds a `service-ready?` fixture that test authors can use to easily ensure that
some service is accepting requests before they begin their tests. An example of it's use is...

```
(deftest my-cool-test
  (fix/with-fixtures [(fix/service-ready? {:http-url "http://my-cool-service"
                                                                   :http-timeout 5000})]
     (is (rad? (http/get "http://my-cool-service")))
```