### PR TITLE
Auto-deploy to clojars for pushed tags matching /^\d+.\d+.\d+/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,11 @@ references:
       - image: circleci/clojure:lein-2.8.1
     working_directory: ~/jackdaw
 
+  deploy_config: &deploy_config
+    docker:
+      - image: circleci/clojure:lein-2.8.1
+    working_directory: /home/circleci/jackdaw
+
   test_config: &test_config
     docker:
       - image: circleci/clojure:lein-2.8.1
@@ -70,6 +75,18 @@ jobs:
           key: v1-jackdaw-{{ .Branch }}-{{ .Revision }}
           paths:
             - .
+  checkout_tags:
+    <<: *build_config
+    steps:
+      - *restore_repo
+      - run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+      - run: git config --global url."https://".insteadOf "git://"
+      - run: git fetch --tags
+      - checkout
+      - save_cache:
+          key: v1-jackdaw-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .
   deps:
     <<: *build_config
     steps:
@@ -81,7 +98,7 @@ jobs:
           key: *mvn_cache_key
           paths:
             - /home/circleci/.m2
-  build:
+  test:
     <<: *test_config
     steps:
       - *restore_repo
@@ -93,16 +110,41 @@ jobs:
       - store_artifacts:
           path: ./logs
 
+  deploy:
+    <<: *deploy_config
+    steps:
+      - *restore_repo
+      - *restore_mvn
+      - run: lein deploy clojars
+
 workflows:
   version: 2
-  build_and_deploy:
+  build_and_test:
     jobs:
       - checkout_code
       - deps:
           context: org-global
           requires:
             - checkout_code
-      - build:
+      - test:
           context: org-global
           requires:
             - deps
+
+  deploy:
+    jobs:
+      - checkout_tags:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/
+      - deploy:
+          context: org-global
+          requires:
+            - checkout_tags
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+/
+            branches:
+              ignore: /.*/

--- a/project.clj
+++ b/project.clj
@@ -46,8 +46,9 @@
               :repositories
               [["confluent"
                 "https://packages.confluent.io/maven/"]
-               ["clojars"
-                "https://clojars.org/repo/"]]}
+               ["clojars" {:url "https://clojars.org/repo/"
+                           :username :env/clojars-username
+                           :password :env/clojars-password}]]}
 
              ;; The dev profile - non-deployment configuration
              :dev


### PR DESCRIPTION
This PR adds a circleci workflow for automatically pushing tagged releases to clojars. The workflow only runs for tags, not branches.

To actually trigger a release therefore, there are a couple of options...

  - use the github release UI to create a release that when published, will commit a corresponding tag to the repo
  - at the command line, something like `git tag -a v0.5.2 -m "Release v0.5.2"`

## TODO

 - [ ] Add clojars credentials to the private project settings (needs project admin)
 - [x] Update branch protection to check for "test" step instead of "build" step (needs project admin)

Maybe resolves #35 