### PR TITLE
Backfill unit tests for jackdaw.admin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -58,6 +58,7 @@
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "0.3.1"]
                              [org.apache.kafka/kafka-streams-test-utils "2.1.0"]
+                             [org.apache.kafka/kafka-clients "2.1.0" :classifier "test"]
                              [org.clojure/test.check "0.9.0"]]
 
               :plugins [[lein-codox "0.10.3"]]

--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -23,33 +23,26 @@
 
 (def client-impl
   {:alter-topics* (fn [this topics]
-                   (d/future
-                     (->> (.alterConfigs this topics)
-                          .all deref)))
+                    (d/future
+                      @(.all (.alterConfigs this topics))))
    :create-topics* (fn [this topics]
                     (d/future
-                      (->> (.createTopics this topics)
-                           .all deref)))
+                      @(.all (.createTopics this topics))))
    :delete-topics*  (fn [this topics]
                       (d/future
-                        (->> (.deleteTopics this topics)
-                             .all deref)))
+                        @(.all (.deleteTopics this topics))))
    :describe-topics* (fn [this topics]
                        (d/future
-                         (->> (.describeTopics this topics (DescribeTopicsOptions.))
-                              .all deref)))
+                         @(.all (.describeTopics this topics (DescribeTopicsOptions.)))))
    :describe-configs* (fn [this configs]
                         (d/future
-                          (->> (.describeConfigs this configs (DescribeConfigsOptions.))
-                               .all .get)))
+                          @(.all (.describeConfigs this configs (DescribeConfigsOptions.)))))
    :describe-cluster* (fn [this]
-                       (d/future
-                         (->> (.describeCluster this (DescribeClusterOptions.))
-                              jd/datafy)))
+                        (d/future
+                          (jd/datafy (.describeCluster this (DescribeClusterOptions.)))))
    :list-topics* (fn [this]
-                  (d/future
-                    (->> (.listTopics this)
-                         .names deref)))})
+                   (d/future
+                     @(.names (.listTopics this))))})
 
 (extend AdminClient
   Client

--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -157,7 +157,7 @@
   This can be used to determine if some set of newly created topics
   are healthy yet, or detect whether leader re-election has finished
   following the demise of a Kafka broker."
-  [client topics]
+  [^AdminClient client topics]
   {:pre [(client? client)
          (sequential? topics)]}
   (->> (describe-topics* client (map :topic-name topics))
@@ -182,7 +182,7 @@
   "Given an `AdminClient` and a sequence of topic descriptors having
   `:topic-config`, alters the live configuration of the specified
   topics to correspond to the specified `:topic-config`."
-  [client topics]
+  [^AdminClient client topics]
   {:pre [(client? client)
          (sequential? topics)]}
   @(alter-topics* client (topics->configs topics)))

--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -24,32 +24,32 @@
 (def client-impl
   {:alter-topics* (fn [this topics]
                    (d/future
-                     (-> (.alterConfigs this topics) .all deref)))
-
+                     (->> (.alterConfigs this topics)
+                          .all deref)))
    :create-topics* (fn [this topics]
                     (d/future
-                      (->> (.createTopics this topics) .all deref)))
-
+                      (->> (.createTopics this topics)
+                           .all deref)))
    :delete-topics*  (fn [this topics]
                       (d/future
-                        (->> (.deleteTopics this topics) .all deref)))
-
+                        (->> (.deleteTopics this topics)
+                             .all deref)))
    :describe-topics* (fn [this topics]
                        (d/future
-                         (->> (.describeTopics this topics) .all deref)))
-
+                         (->> (.describeTopics this topics (DescribeTopicsOptions.))
+                              .all deref)))
    :describe-configs* (fn [this configs]
                         (d/future
-                          (-> (.describeConfigs this configs (DescribeConfigsOptions.))
-                              .all .get)))
+                          (->> (.describeConfigs this configs (DescribeConfigsOptions.))
+                               .all .get)))
    :describe-cluster* (fn [this]
                        (d/future
-                         (-> (.describeCluster this (DescribeClusterOptions.))
-                             jd/datafy)))
-
+                         (->> (.describeCluster this (DescribeClusterOptions.))
+                              jd/datafy)))
    :list-topics* (fn [this]
                   (d/future
-                    (->> (.listTopics this) .names deref)))})
+                    (->> (.listTopics this)
+                         .names deref)))})
 
 (extend AdminClient
   Client

--- a/test/jackdaw/admin_test.clj
+++ b/test/jackdaw/admin_test.clj
@@ -1,14 +1,12 @@
 (ns jackdaw.admin-test
   (:require
    [clojure.test :refer :all]
-   [clojure.spec.alpha :as s]
    [jackdaw.admin :as admin]
    [jackdaw.data :as data]
    [manifold.deferred :as d])
   (:import
    (org.apache.kafka.common Node KafkaFuture)
-   (org.apache.kafka.clients.admin MockAdminClient
-    DescribeTopicsOptions DescribeClusterOptions DescribeConfigsOptions)))
+   (org.apache.kafka.clients.admin MockAdminClient)))
 
 (extend MockAdminClient
   admin/Client
@@ -73,7 +71,6 @@
   (with-mock-admin-client test-cluster
     (fn [client]
       (admin/create-topics! client (vals test-topics))
-
       (doseq [[k info] test-topics]
         (is (admin/topic-exists? client info))))))
 
@@ -104,7 +101,6 @@
         (is (set= [:is-internal? :partition-info]
                   (keys topic-info)))))))
 
-
 (deftest test-describe-cluster
   (with-mock-admin-client test-cluster
     (fn [client]
@@ -130,7 +126,6 @@
         (admin/delete-topics! client [foo])
         (is (= [{:topic-name "bar"}]
                (admin/list-topics client)))))))
-
 
 (deftest test-alter-topic-config!
   (with-mock-admin-client test-cluster

--- a/test/jackdaw/admin_test.clj
+++ b/test/jackdaw/admin_test.clj
@@ -1,0 +1,133 @@
+(ns jackdaw.admin-test
+  (:require
+   [clojure.test :refer :all]
+   [clojure.spec.alpha :as s]
+   [jackdaw.admin :as admin]
+   [jackdaw.data :as data]
+   [manifold.deferred :as d])
+  (:import
+   (org.apache.kafka.common Node)
+   (org.apache.kafka.clients.admin
+    MockAdminClient DescribeTopicsOptions DescribeClusterOptions)))
+
+(defn set= [a b]
+  (= (set a)
+     (set b)))
+
+(def test-topics
+  {:foo {:topic-name "foo"
+         :partition-count 15
+         :replication-factor 3
+         :topic-config {}}
+
+   :bar {:topic-name "bar"
+         :partition-count 15
+         :replication-factor 3
+         :topic-config {}}})
+
+(defn node-seq [id host]
+  (lazy-seq
+   (cons (Node. id (str host "-" id) 1234)
+         (node-seq (inc id) host))))
+
+(def test-cluster (take 3 (node-seq 0 "test-host")))
+
+(defn with-mock-admin-client [cluster f]
+  (let [client (MockAdminClient. cluster (first cluster))]
+    (f client)))
+
+(deftest test-new-topic
+  (doseq [[k info] test-topics]
+    (let [t (data/map->NewTopic info)
+          msg (format "cannot create topic from %s" t)]
+      (is (instance? org.apache.kafka.clients.admin.NewTopic t) msg))))
+
+(deftest test-create-topics!
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+      (is (set= (map :topic-name (vals test-topics))
+                (keys (admin/describe-topics client)))))))
+
+(deftest test-list-topics
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+      (is (set= (map #(select-keys % [:topic-name]) (vals test-topics))
+                (admin/list-topics client))))))
+
+(deftest test-topic-exists?
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+
+      (doseq [[k info] test-topics]
+        (is (admin/topic-exists? client info))))))
+
+(deftest test-retry-exists?
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (testing "returns true if the topic is created within specified time"
+        (let [foo (:foo test-topics)
+              p (d/future
+                  (admin/retry-exists? client foo 3 30))]
+          (Thread/sleep 50)
+          (admin/create-topics! client [foo])
+          (is (= true @p))))
+
+      (testing "returns false if the topic is not created within specified time"
+        (let [bar (:bar test-topics)
+              p (d/future
+                  (admin/retry-exists? client bar 3 30))]
+          (Thread/sleep 100)
+          (admin/create-topics! client [bar])
+          (is (= false @p)))))))
+
+(deftest test-describe-topics
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+      (doseq [[topic-name topic-info] (admin/describe-topics client)]
+        (is (set= [:is-internal? :partition-info]
+                  (keys topic-info)))))))
+
+
+(deftest test-describe-cluster
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+      (is (set= [:cluster-id :controller :nodes]
+                (keys (admin/describe-cluster client)))))))
+
+(deftest test-partition-ids-of-topics
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (admin/create-topics! client (vals test-topics))
+      (doseq [[t info] test-topics]
+        (is (= (:partition-count info)
+               (-> (admin/partition-ids-of-topics client)
+                   (get (name t))
+                   count)))))))
+
+(deftest test-delete-topics!
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (let [{:keys [foo bar]} test-topics]
+        (admin/create-topics! client [foo bar])
+        (admin/delete-topics! client [foo])
+        (is (= [{:topic-name "bar"}]
+               (admin/list-topics client)))))))
+
+
+(deftest test-alter-topic-config!
+  (with-mock-admin-client test-cluster
+    (fn [client]
+      (let [{:keys [foo bar]} test-topics]
+        (admin/create-topics! client [foo bar])
+
+        (admin/alter-topic-config!
+         client (map #(update % :replication-factor inc)
+                     [foo bar]))
+
+        (admin/describe-topics-configs
+         client [foo bar]))))

--- a/test/jackdaw/test/transports/rest_proxy_test.clj
+++ b/test/jackdaw/test/transports/rest_proxy_test.clj
@@ -17,9 +17,12 @@
 (def kafka-config {"bootstrap.servers" "localhost:9092"
                    "group.id" "kafka-write-test"})
 
+(def +real-rest-proxy-url+
+  "http://localhost:8082")
+
 (defn rest-proxy-config
   [group-id]
-  {:bootstrap-uri "http://localhost:8082"
+  {:bootstrap-uri +real-rest-proxy-url+
    :group-id group-id})
 
 (defn kstream-config
@@ -67,8 +70,9 @@
   (fix/with-fixtures [(fix/topic-fixture kafka-config topic-config)
                       (fix/skip-to-end {:topic test-in
                                         :config kafka-config})
-                      (fix/kstream-fixture (kstream-config app app-id))]
-
+                      (fix/kstream-fixture (kstream-config app app-id))
+                      (fix/service-ready? {:http-url +real-rest-proxy-url+
+                                           :http-timeout 5000})]
     (with-open [machine (jd.test/test-machine (transport))]
       (log/info "begin" app-id)
       (let [result (f machine)]


### PR DESCRIPTION
I looked into the admin ns because it had quite low test coverage. Think I might have found a bug and hopefully improved test coverage a bit with some of the easier tests. The remaining functions will be a bit more difficult because the MockAdminClient doesn't cover all the methods we use on the AdminClient.