### PR TITLE
Support nil message keys in the rest-proxy

### DIFF
--- a/src/jackdaw/test/transports/rest_proxy.clj
+++ b/src/jackdaw/test/transports/rest_proxy.clj
@@ -30,8 +30,9 @@
 
 (defn- base64-decode
   [decodable]
-  (let [decoder (Base64/getDecoder)]
-    (.decode decoder decodable)))
+  (when decodable
+    (let [decoder (Base64/getDecoder)]
+      (.decode decoder decodable))))
 
 (defn undatafy-record
   [topic-metadata m]


### PR DESCRIPTION
One of our older apps publishes messages with null message keys 😢...