### PR TITLE
Report test coverage to codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,9 +106,16 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          lein test
+          lein with-profile +test cloverage --codecov
       - store_artifacts:
           path: ./logs
+      - store_artifacts:
+          path: target/coverage
+      - store_test_results:
+          path: target/test-results
+      - run:
+          name: Report Test Coverage
+          command: bash <(curl -s https://codecov.io/bash)
 
   deploy:
     <<: *deploy_config

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Jackdaw is a Clojure library for the Apache Kafka distributed streaming platform
 To use the latest release, add the following to your project:
 
 [![Clojars Project](https://img.shields.io/clojars/v/fundingcircle/jackdaw.svg)](https://clojars.org/fundingcircle/jackdaw)
+[![Code Coverage](https://codecov.io/gh/FundingCircle/jackdaw/branch/master/graph/badge.svg)](https://codecov.io/gh/FundingCircle/jackdaw)
 
 ## Documentation
 

--- a/project.clj
+++ b/project.clj
@@ -67,7 +67,8 @@
                :source-uri "http://github.com/fundingcircle/jackdaw/blob/{version}/{filepath}#L{line}"}}
 
              :test
-             {:resource-paths ["test/resources"]}
+             {:resource-paths ["test/resources"]
+              :plugins [[lein-cloverage "1.0.13"]]}
 
              ;; This is not in fact what lein defines repl to be
              :repl


### PR DESCRIPTION
Extracts the cloverage part out of #16. Back when that was first created, the ci pipeline was a bit more complicated. Much simpler to run code coverage as part of the test step now.