### PR TITLE
Parameterize test environment variables

### DIFF
--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -5,6 +5,7 @@
             [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.pprint :refer [pprint]]
+            [jackdaw.test-config :refer [test-config]]
             [jackdaw.serdes.avro :as avro]
             [jackdaw.serdes.avro.schema-registry :as reg])
   (:import [java.nio ByteBuffer]
@@ -34,8 +35,9 @@
 (defn ->serde [schema-str]
   (let [schema-registry-config
         {:avro.schema-registry/client (reg/mock-client)
-         :avro.schema-registry/url    "localhost:8081"}
-
+         :avro.schema-registry/url    (format "%s:%s"
+                                              (get-in (test-config) [:schema-registry :host])
+                                              (get-in (test-config) [:schema-registry :port]))}
         serde-config
         {:avro/schema schema-str
          :key?        false}]

--- a/test/jackdaw/test/commands/write_test.clj
+++ b/test/jackdaw/test/commands/write_test.clj
@@ -5,6 +5,7 @@
    [jackdaw.test.transports.kafka]
    [jackdaw.test.serde :as serde]
    [jackdaw.test :refer [test-machine]]
+   [jackdaw.test-config :refer [test-config]]
    [clojure.test :refer :all])
   (:import
     [clojure.lang ExceptionInfo]))
@@ -39,7 +40,9 @@
                    :key-serde :long
                    :value-serde :json}))
 
-(def kafka-config {"bootstrap.servers" "localhost:9092"
+(def kafka-config {"bootstrap.servers" (format "%s:%s"
+                                               (get-in (test-config) [:broker :host])
+                                               (get-in (test-config) [:broker :port]))
                    "group.id" "kafka-write-test"})
 
 (defn with-transport

--- a/test/jackdaw/test/fixtures_test.clj
+++ b/test/jackdaw/test/fixtures_test.clj
@@ -1,7 +1,8 @@
 (ns jackdaw.test.fixtures-test
   (:require
    [clojure.test :refer :all]
-   [jackdaw.test.fixtures :refer :all])
+   [jackdaw.test.fixtures :refer :all]
+   [jackdaw.test-config :refer [test-config]])
   (:import
    (org.apache.kafka.clients.admin AdminClient NewTopic)))
 
@@ -12,7 +13,9 @@
    :config {}})
 
 (def kafka-config
-  {"bootstrap.servers" "localhost:9092"})
+  {"bootstrap.servers" (format "%s:%s"
+                               (get-in (test-config) [:broker :host])
+                               (get-in (test-config) [:broker :port]))})
 
 (def test-topics
   (let [topics {"foo" topic-foo}]

--- a/test/jackdaw/test/transports/kafka_test.clj
+++ b/test/jackdaw/test/transports/kafka_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [jackdaw.streams :as k]
    [jackdaw.test :as jd.test]
+   [jackdaw.test-config :refer [test-config]]
    [jackdaw.test.fixtures :as fix]
    [jackdaw.test.journal :refer [with-journal watch-for]]
    [jackdaw.test.serde :as serde]
@@ -14,13 +15,17 @@
   (:import
    (java.util Properties)))
 
-(def kafka-config {"bootstrap.servers" "localhost:9092"
+(def kafka-config {"bootstrap.servers" (format "%s:%s"
+                                               (get-in (test-config) [:broker :host])
+                                               (get-in (test-config) [:broker :port]))
                    "group.id" "kafka-write-test"})
 
 (defn kstream-config
   [app app-id]
   {:topology app
-   :config {"bootstrap.servers" "localhost:9092"
+   :config {"bootstrap.servers" (format "%s:%s"
+                                        (get-in (test-config) [:broker :host])
+                                        (get-in (test-config) [:broker :port]))
             "application.id" app-id}})
 
 (defn echo-stream

--- a/test/jackdaw/test/transports/mock_test.clj
+++ b/test/jackdaw/test/transports/mock_test.clj
@@ -6,6 +6,7 @@
    [jackdaw.test.journal :refer [with-journal watch-for]]
    [jackdaw.test.transports.mock :as mock]
    [jackdaw.test :as jd.test]
+   [jackdaw.test-config :refer [test-config]]
    [jackdaw.test.transports :as trns]
    [jackdaw.test.serde :as serde]
    [manifold.stream :as s])
@@ -57,7 +58,9 @@
   []
   (trns/transport {:type :mock
                    :driver (test-driver (echo-stream test-in test-out)
-                                        {"bootstrap.servers" "localhost:9092"
+                                        {"bootstrap.servers" (format "%s:%s"
+                                                                     (get-in (test-config) [:broker :host])
+                                                                     (get-in (test-config) [:broker :port]))
                                          "application.id" "test-echo-stream"})
                    :topics {"test-in" test-in
                             "test-out" test-out}}))

--- a/test/jackdaw/test/transports/rest_proxy_test.clj
+++ b/test/jackdaw/test/transports/rest_proxy_test.clj
@@ -5,6 +5,7 @@
    [clojure.test :refer :all]
    [jackdaw.streams :as k]
    [jackdaw.test :as jd.test]
+   [jackdaw.test-config :refer [test-config]]
    [jackdaw.test.fixtures :as fix]
    [jackdaw.test.serde :as serde]
    [jackdaw.test.journal :refer [with-journal watch-for]]
@@ -14,11 +15,15 @@
   (:import
    (java.util Properties)))
 
-(def kafka-config {"bootstrap.servers" "localhost:9092"
+(def kafka-config {"bootstrap.servers" (format "%s:%s"
+                                               (get-in (test-config) [:broker :host])
+                                               (get-in (test-config) [:broker :port]))
                    "group.id" "kafka-write-test"})
 
 (def +real-rest-proxy-url+
-  "http://localhost:8082")
+  (format "http://%s:%s"
+          (get-in (test-config) [:kafka-rest :host])
+          (get-in (test-config) [:kafka-rest :port])))
 
 (defn rest-proxy-config
   [group-id]
@@ -28,7 +33,9 @@
 (defn kstream-config
   [app app-id]
   {:topology app
-   :config {"bootstrap.servers" "localhost:9092"
+   :config {"bootstrap.servers" (format "%s:%s"
+                                        (get-in (test-config) [:broker :host])
+                                        (get-in (test-config) [:broker :port]))
             "application.id" app-id}})
 
 (defn echo-stream

--- a/test/jackdaw/test_config.clj
+++ b/test/jackdaw/test_config.clj
@@ -1,0 +1,18 @@
+(ns jackdaw.test-config)
+
+(defn test-config
+  []
+  (let [e (System/getenv)]
+    {
+     :broker            {:host (get e "BROKER_HOST" "localhost")
+                         :port (get e "BROKER_PORT" 9092)}
+
+     :kafka-rest        {:host (get e "KAFKA_REST_HOST" "localhost")
+                         :port (get e "KAFKA_REST_PORT" 8082)}
+
+     :schema-registry   {:host (get e "SCHEMA_REGISTRY_HOST" "localhost")
+                         :port (get e "SCHEMA_REGISTRY_PORT" 8081)}
+
+     :zookeeper         {:host (get e "ZOOKEEPER_HOST" "localhost")
+                         :port (get e "ZOOKEEPER_PORT" 2181)}
+     }))

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -4,6 +4,7 @@
    [jackdaw.serdes.avro.schema-registry :as reg]
    [jackdaw.streams :as k]
    [jackdaw.test :as jd.test]
+   [jackdaw.test-config :refer [test-config]]
    [jackdaw.test.commands :as cmd]
    [jackdaw.test.fixtures :as fix]
    [jackdaw.test.serde :as serde]
@@ -36,7 +37,9 @@
                    :key-serde :string
                    :value-serde :json}))
 
-(def kafka-config {"bootstrap.servers" "localhost:9092"
+(def kafka-config {"bootstrap.servers" (format "%s:%s"
+                                               (get-in (test-config) [:broker :host])
+                                               (get-in (test-config) [:broker :port]))
                    "group.id" "kafka-write-test"})
 
 (defn kafka-transport


### PR DESCRIPTION
Parameterize the test-config so that the tests can be run against any host/port, not just localhost.