### PR TITLE
Add integration tests for client namespace

### DIFF
--- a/src/jackdaw/client.clj
+++ b/src/jackdaw/client.clj
@@ -22,6 +22,7 @@
            org.apache.kafka.common.serialization.Serde))
 
 (set! *warn-on-reflection* true)
+(declare assignment)
 
 ;;;; Producer
 
@@ -119,11 +120,6 @@
   [^KafkaConsumer consumer]
   (.subscription consumer))
 
-(defn assignment
-  "Return the assigned topics and partitions of a consumer."
-  [^KafkaConsumer consumer]
-  (map jd/datafy (.assignment consumer)))
-
 (defn subscribe
   "Subscribe a consumer to the specified topics.
 
@@ -160,10 +156,10 @@
   producer."
   [producer-or-consumer {:keys [^String topic-name]}]
   (->> (cond (instance? KafkaConsumer producer-or-consumer)
-             (.partitionsFor ^KafkaConsumer consumer topic-name)
+             (.partitionsFor ^KafkaConsumer producer-or-consumer topic-name)
 
              (instance? KafkaProducer producer-or-consumer)
-             (.partitionsFor ^KafkaProducer consumer topic-name)
+             (.partitionsFor ^KafkaProducer producer-or-consumer topic-name)
 
              :else (throw (ex-info "Got non producer/consumer!"
                                    {:inst producer-or-consumer
@@ -305,3 +301,8 @@
                         (map (fn [^PartitionInfo x]
                                (TopicPartition. (.topic x) (.partition x)))))]
     (apply assign consumer partitions)))
+
+(defn assignment
+  "Return the assigned topics and partitions of a consumer."
+  [^KafkaConsumer consumer]
+  (map jd/datafy (.assignment consumer)))

--- a/src/jackdaw/data/common.clj
+++ b/src/jackdaw/data/common.clj
@@ -1,6 +1,7 @@
 (in-ns 'jackdaw.data)
 
 (import '[org.apache.kafka.common
+          PartitionInfo
           Node TopicPartition TopicPartitionInfo])
 
 ;;; Node
@@ -12,6 +13,17 @@
    :port (.port node)
    :id (.id node)
    :rack (.rack node)})
+
+;;; PartitionInfo
+
+(defn->data PartitionInfo->data
+  [^PartitionInfo pi]
+  {:topic (.topic pi)
+   :isr (mapv datafy (.inSyncReplicas pi))
+   :leader (datafy (.leader pi))
+   :replicas (mapv datafy (.replicas pi))
+   :partition (.partition pi)
+   :offline-replicas (mapv datafy (.offlineReplicas pi))})
 
 ;;; TopicPartitionInfo
 

--- a/test/jackdaw/client_test.clj
+++ b/test/jackdaw/client_test.clj
@@ -1,11 +1,84 @@
 (ns jackdaw.client-test
   (:require [clojure.test :refer :all]
-            [jackdaw.client :as client])
+            [jackdaw.admin :as admin]
+            [jackdaw.client :as client]
+            [jackdaw.test.fixtures :as fix]
+            [jackdaw.test.serde :as serde]
+            [jackdaw.data :as data])
   (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]
            java.time.Duration
            [org.apache.kafka.clients.consumer Consumer ConsumerRecord ConsumerRecords]
            [org.apache.kafka.clients.producer Producer]
            org.apache.kafka.common.TopicPartition))
+
+(def foo-topic
+  (serde/resolver {:topic-name "foo"
+                   :replication-factor 1
+                   :partition-count 1
+                   :key-serde :string
+                   :value-serde :json}))
+
+(def bar-topic
+  (serde/resolver {:topic-name "bar"
+                   :replication-factor 1
+                   :partition-count 1
+                   :key-serde :string
+                   :value-serde :json}))
+
+(def high-partition-topic
+  (serde/resolver {:topic-name "high-partition-topic"
+                   :replication-factor 1
+                   :partition-count 15
+                   :key-serde :string
+                   :value-serde :json}))
+
+(def test-topics
+  {"foo" foo-topic
+   "bar" bar-topic
+   "high-partition-topic" high-partition-topic})
+
+(defn broker-config []
+  {"bootstrap.servers" "localhost:9092"})
+
+(defn producer-config [group-id]
+  (-> (broker-config)
+      (merge {"key.serializer" (.getName org.apache.kafka.common.serialization.StringSerializer)
+              "value.serializer" (.getName org.apache.kafka.common.serialization.StringSerializer)})))
+
+(defn consumer-config [group-id]
+  (-> (broker-config)
+      (merge {"group.id" group-id
+              "key.deserializer" (.getName org.apache.kafka.common.serialization.StringDeserializer)
+              "value.deserializer" (.getName org.apache.kafka.common.serialization.StringDeserializer)})))
+
+;; Producer API
+;;
+
+(defn with-producer [producer f]
+  (with-open [p producer]
+    (f p)))
+
+(def +response-keys+
+  {:send! [:topic-name :partition  :offset
+           :timestamp
+           :serialized-key-size :serialized-value-size]
+
+   :produce! [:topic-name :partition  :offset
+              :timestamp
+              :serialized-key-size :serialized-value-size]
+
+   :partitions-for [:topic :isr :leader :replicas :partition :offline-replicas]})
+
+(defn response-ok? [response-for x]
+  (every? #(contains? x %) (get +response-keys+ response-for)))
+
+(defn callback-ok? [x]
+  (= :ok x))
+
+(deftest producer-test
+  (with-producer (client/producer (producer-config "producer-test"))
+    (fn [producer]
+      (is (instance? Producer producer)))))
 
 (deftest callback-test
   (testing "producer callbacks"
@@ -29,25 +102,128 @@
         (.onCompletion cb nil ex)
         (is (= ex @result))))))
 
-(defn poll-result [topic data]
-  (let [partition 1
-        offset 1]
-    (ConsumerRecords.
-     {(TopicPartition. topic partition)
-      (map (fn [[k v]]
-             (ConsumerRecord. topic partition offset k v)) data)})))
 
-(deftest consumer-test
+(deftest ^:integration send!-test
+  (fix/with-fixtures [(fix/topic-fixture (broker-config) test-topics 1000)]
+    (with-producer (client/producer (producer-config "send-test"))
+      (fn [producer]
+        (testing "simple send"
+          (let [msg (data/->ProducerRecord {:topic-name "foo"} "1" "one")
+                result (client/send! producer msg)]
+            (is (response-ok? :send! @result))))
+
+        (testing "send with callback"
+          (let [msg (data/->ProducerRecord {:topic-name "foo"} "1" "one")
+                on-callback (promise)
+                result (client/send! producer msg (fn [meta ex]
+                                                    (if ex
+                                                      (deliver on-callback ex)
+                                                      (deliver on-callback :ok))))]
+            (is (response-ok? :send! @result))
+            (is (callback-ok? @on-callback))))))))
+
+(deftest ^:integration produce!-test
+  (fix/with-fixtures [(fix/topic-fixture (broker-config) test-topics 1000)]
+    (with-producer (client/producer (producer-config "produce-test"))
+      (fn [producer]
+        (let [{:keys [topic key value partition timestamp headers]}
+              {:topic     foo-topic
+               :key       "1"
+               :value     "one"
+               :partition 0
+               :timestamp (System/currentTimeMillis)
+               :headers {}}]
+
+          (testing "topic, value"
+            (is (response-ok? :produce! @(client/produce! producer topic value))))
+
+          (testing "topic, key, value"
+            (is (response-ok? :produce! @(client/produce! producer topic key value))))
+
+          (testing "topic, partition, key, value"
+            (is (response-ok? :produce! @(client/produce! producer topic partition key value))))
+
+          (testing "topic, partition, timestamp, key, value"
+            (is (response-ok? :produce! @(client/produce! producer topic partition timestamp key value))))
+
+          (testing "topic, partition, timestamp, key, value, headers"
+            (is (response-ok? :produce @(client/produce! producer topic partition timestamp key value headers)))))))))
+
+;; Consumer API
+
+(defn with-consumer [consumer f]
+  (with-open [c consumer]
+    (f c)))
+
+(deftest ^:integration consumer-test
   (let [config {"bootstrap.servers" "localhost:9092"
                 "key.deserializer" "org.apache.kafka.common.serialization.StringDeserializer"
-                "value.deserializer" "org.apache.kafka.common.serialization.StringDeserializer"}]
-    (is (instance? Consumer (client/consumer config)))))
+                "value.deserializer" "org.apache.kafka.common.serialization.StringDeserializer"}
+        key-serde (:key-serde foo-topic)
+        value-serde (:value-serde foo-topic)]
 
-(deftest producer-test
-  (let [config {"bootstrap.servers" "localhost:9092"
-                "key.serializer" "org.apache.kafka.common.serialization.StringSerializer"
-                "value.serializer" "org.apache.kafka.common.serialization.StringSerializer"}]
-    (is (instance? Producer (client/producer config)))))
+    (testing "create with config"
+      (with-consumer (client/consumer config)
+        (fn [consumer]
+          (is (instance? Consumer consumer)))))
+
+
+    (testing "create with config and serdes"
+      (with-consumer (client/consumer config {:key-serde key-serde
+                                              :value-serde value-serde})
+        (fn [consumer]
+          (is (instance? Consumer consumer)))))
+
+    (testing "topic subscription"
+      (with-consumer (-> (client/consumer config)
+                         (client/subscribe [foo-topic]))
+        (fn [consumer]
+          (is (instance? Consumer consumer))
+          (is (= #{"foo"}
+                 (client/subscription consumer))))))
+
+    (testing "topic assignment"
+      (with-consumer (-> (client/consumer config)
+                         (client/assign-all (map :topic-name [foo-topic])))
+        (fn [consumer]
+          (is (instance? Consumer consumer))
+          (is (= [{:topic-name "foo" :partition 0}]
+                 (client/assignment consumer))))))))
+
+(deftest ^:integration partitions-for-test
+  (fix/with-fixtures [(fix/topic-fixture (broker-config) test-topics 1000)]
+    (let [key-serde (:key-serde high-partition-topic)
+          value-serde (:value-serde high-partition-topic)]
+
+      (testing "partition info"
+        (with-consumer (-> (client/consumer (consumer-config "partition-test"))
+                           (client/subscribe [bar-topic]))
+          (fn [consumer]
+            (let [[pinfo] (-> (client/partitions-for consumer bar-topic)
+                              (data/datafy))]
+              (is (response-ok? :partitions-for pinfo))))))
+
+      (testing "single-partition consumer"
+        (with-consumer (-> (client/consumer (consumer-config "partition-test"))
+                           (client/subscribe [bar-topic]))
+          (fn [consumer]
+            (is (= 1 (client/num-partitions consumer bar-topic))))))
+
+      (testing "multi-partition consumer"
+        (with-consumer (-> (client/consumer (consumer-config "partition-test"))
+                           (client/subscribe [high-partition-topic]))
+          (fn [consumer]
+            (is (= 15 (client/num-partitions consumer high-partition-topic))))))
+
+      (testing "single-partition producer"
+        (with-producer (client/producer (producer-config "partition-test"))
+          (fn [producer]
+            (is (= 1 (client/num-partitions producer bar-topic))))))
+
+      (testing "multi-partition producer"
+        (with-producer (client/producer (producer-config "partition-test"))
+          (fn [producer]
+            (is (= 15 (client/num-partitions producer high-partition-topic)))))))))
 
 (defn mock-consumer
   "Returns a consumer that will return the supplied items (as ConsumerRecords)
@@ -58,6 +234,14 @@
       (.poll queue ms TimeUnit/MILLISECONDS))
     (^ConsumerRecords poll [this ^Duration duration]
      (.poll queue (.toMillis duration) TimeUnit/MILLISECONDS))))
+
+(defn poll-result [topic data]
+  (let [partition 1
+        offset 1]
+    (ConsumerRecords.
+     {(TopicPartition. topic partition)
+      (map (fn [[k v]]
+             (ConsumerRecord. topic partition offset k v)) data)})))
 
 (deftest poll-test
   (let [q (LinkedBlockingQueue.)


### PR DESCRIPTION
Adds a bunch of tests for the client namespace. This PR covers the following aspects.

  - basic consumer/producer creation and teardown
  - send!, produce!
  - topic subscription and assignment
  - topic partition interrogation

There's still a bit more that remains without tests like offset setting/getting but these features are used by the test-machine's own test-suite.