### PR TITLE
Add tests for client seek behavior

### DIFF
--- a/src/jackdaw/data/common.clj
+++ b/src/jackdaw/data/common.clj
@@ -18,7 +18,7 @@
 
 (defn->data PartitionInfo->data
   [^PartitionInfo pi]
-  {:topic (.topic pi)
+  {:topic-name (.topic pi)
    :isr (mapv datafy (.inSyncReplicas pi))
    :leader (datafy (.leader pi))
    :replicas (mapv datafy (.replicas pi))
@@ -62,8 +62,9 @@
         o
 
         (map? o)
-        (or (:clojure.datafy/obj (meta o))
-            (map->TopicPartition o))
+        (if (= TopicPartition (:clojure.datafy/class (meta o)))
+          (:clojure.datafy/obj (meta o))
+          (map->TopicPartition o))
 
         :else
         (throw (ex-info "Unable to build TopicPartition"

--- a/src/jackdaw/data/consumer.clj
+++ b/src/jackdaw/data/consumer.clj
@@ -68,6 +68,26 @@
   ;; on 1.10+
   (datafy *1))
 
+;;; OffsetAndTimestamp tuples
+
+(defn ^OffsetAndTimestamp ->OffsetAndTimestamp
+  [{:keys [offset timestamp]}]
+  (OffsetAndTimestamp. offset (long timestamp)))
+
 (defn->data OffsetAndTimestamp->data [^OffsetAndTimestamp ots]
   {:offset (.offset ots)
    :timestamp (.timestamp ots)})
+
+(defn map->OffsetAndTimestamp
+  [{:keys [offset timestamp] :as m}]
+  (->OffsetAndTimestamp m))
+
+(defn as-OffsetAndTimestamp
+  [ot]
+  (cond (instance? OffsetAndTimestamp ot)
+        ot
+
+        (map? ot)
+        (if (= OffsetAndTimestamp (:clojure.datafy/class (meta ot)))
+          (:clojure.datafy/obj (meta ot))
+          (map->OffsetAndTimestamp ot))))


### PR DESCRIPTION
This PR focuses on testing the facilities provides by the client namespace to seek to some known point in a topic. For example

  - seek to the beginning of a topic
  - seek to the end of a topic
  - seek to last offset before some timestamp

The tests for this work by creating a randomly named topic and seeing it with a few records. The test then exercises each scenario above and checks that the consumers next offset is as expected.