### PR TITLE
Allow usage of timestamp extractor and reset policy in topic config

### DIFF
--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -27,8 +27,8 @@
 
 (set! *warn-on-reflection* true)
 
-(defn topic->consumed [{:keys [key-serde value-serde]}]
-  (Consumed/with key-serde value-serde))
+(defn topic->consumed [{:keys [key-serde value-serde timestamp-extractor reset-policy]}]
+  (Consumed/with key-serde value-serde timestamp-extractor reset-policy))
 
 (defn topic->produced [{:keys [key-serde value-serde]}]
   (Produced/with key-serde value-serde))

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -23,12 +23,18 @@
             TimeWindowedKStream ValueJoiner ValueMapper
             ValueMapperWithKey ValueTransformerSupplier Windows]
            [org.apache.kafka.streams.processor
-            StreamPartitioner]))
+            StreamPartitioner]
+           [org.apache.kafka.streams
+            Topology$AutoOffsetReset]))
+
 
 (set! *warn-on-reflection* true)
 
 (defn topic->consumed [{:keys [key-serde value-serde timestamp-extractor reset-policy]}]
-  (Consumed/with key-serde value-serde timestamp-extractor reset-policy))
+  (let [reset-policy (and reset-policy
+                          (Topology$AutoOffsetReset/valueOf
+                           (str/upper-case (name reset-policy))))]
+    (Consumed/with key-serde value-serde timestamp-extractor reset-policy)))
 
 (defn topic->produced [{:keys [key-serde value-serde]}]
   (Produced/with key-serde value-serde))

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -10,7 +10,8 @@
                      IKGroupedStream IKStream IKTable
                      ITimeWindowedKStream ISessionWindowedKStream]])
   (:import org.apache.kafka.common.serialization.Serde
-           org.apache.kafka.streams.kstream.JoinWindows))
+           org.apache.kafka.streams.kstream.JoinWindows
+           org.apache.kafka.streams.processor.TimestampExtractor))
 
 (def global-ktable?
   (partial satisfies? IGlobalKTable))
@@ -39,17 +40,24 @@
 (def serde?
   (partial instance? Serde))
 
+(def timestamp-extractor?
+  (partial instance? TimestampExtractor))
+
 (def streams-builder?
   (partial satisfies? IStreamsBuilder))
 
 (s/def ::topic-name string?)
 (s/def ::key-serde any?)
 (s/def ::value-serde any?)
+(s/def ::timestamp-extractor timestamp-extractor?)
+(s/def ::reset-policy keyword?)
 
 (s/def ::topic-config
   (s/keys :req-un [::topic-name
                    ::key-serde
-                   ::value-serde]))
+                   ::value-serde]
+          :opt-un [::timestamp-extractor
+                   ::reset-policy]))
 
 (s/def ::topic-configs (s/coll-of ::topic-config))
 


### PR DESCRIPTION
If `nil` the defaults from stream config will be used.