### PR TITLE
Sanitize branch names for things that shouldn't be in a filename

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -34,8 +34,10 @@
        tag
        (let [[_ prefix patch] (re-find #"(\d+\.\d+)\.(\d+)" tag)
              patch            (Long/parseLong patch)
-             patch+           (inc patch)]
-         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))))}
+             patch+           (inc patch)
+             branch+          (-> branch
+                                  (.replaceAll "[^a-zA-Z0-9]" "_"))]
+         (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch+))))}
 
   :profiles {;; Provide an alternative to :leiningen/default, used to include :shared
              :default


### PR DESCRIPTION
The `lein-git-deps` plugin uses the branch name as part of the filename when building a jar (or rather our configuration of it does). This just replaces anything not in `[a-zA-Z0-9]` in the branch name with an underscore in the generated jar (and subsequent publication to clojars)