### PR TITLE
Test machine bug fixes

### DIFF
--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -130,10 +130,12 @@
     ;; run commands, stopping if one fails.
     {:results (loop [results []
                      cmd-list commands]
-                (let [r (exe (first cmd-list))]
-                  (if (or (contains? r :error) (empty? (rest cmd-list)))
-                    (conj results r)
-                    (recur (conj results r) (rest cmd-list)))))
+                (cond
+                  (first cmd-list) (let [r (exe (first cmd-list))]
+                                     (if (or (contains? r :error) (empty? (rest cmd-list)))
+                                       (conj results r)
+                                       (recur (conj results r) (rest cmd-list))))
+                  :else results))
      :journal @(:journal machine)}))
 
 (defn identity-transport

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -28,6 +28,7 @@
    [jackdaw.test.transports.identity]
    [jackdaw.test.transports.kafka]
    [jackdaw.test.transports.mock]
+   [jackdaw.test.transports.rest-proxy]
    [jackdaw.test.journal :refer [with-journal]]
    [jackdaw.test.middleware :refer [with-timing with-status with-journal-snapshots]]))
 

--- a/src/jackdaw/test/transports.clj
+++ b/src/jackdaw/test/transports.clj
@@ -1,11 +1,23 @@
 (ns jackdaw.test.transports)
 
+(defonce +transports+ (atom #{}))
+
 (defmulti transport (fn [config]
                       (:type config)))
+
+(defn supported-transports []
+  @+transports+)
 
 (defmethod transport :default
   [cfg]
   (throw (ex-info "unable to find transport to satisfy config" {})))
+
+(defmacro deftransport [transport-type args & body]
+  `(do
+     (defmethod transport ~transport-type
+       ~args
+       ~@body)
+     (swap! +transports+ conj ~transport-type)))
 
 (defn with-transport
   [machine transport]

--- a/src/jackdaw/test/transports/identity.clj
+++ b/src/jackdaw/test/transports/identity.clj
@@ -4,7 +4,7 @@
    [manifold.stream :as s]
    [manifold.deferred :as d]
    [jackdaw.test.journal :as j]
-   [jackdaw.test.transports :as t]))
+   [jackdaw.test.transports :as t :refer [deftransport]]))
 
 (defn identity-consumer
   [stream]
@@ -17,7 +17,7 @@
   (let [messages (s/stream 1)]
     {:messages messages}))
 
-(defmethod t/transport :identity
+(deftransport :identity
   [{:keys [topics]}]
   (let [ch (s/stream 1)
         test-consumer (identity-consumer ch)

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -6,7 +6,7 @@
    [jackdaw.client :as kafka]
    [jackdaw.data :as jd]
    [jackdaw.test.commands :as cmd]
-   [jackdaw.test.transports :as t]
+   [jackdaw.test.transports :as t :refer [deftransport]]
    [jackdaw.test.serde :refer [apply-serializers apply-deserializers
                                serde-map
                                byte-array-serde]])
@@ -188,7 +188,7 @@
      {:producer  producer
       :messages  messages})))
 
-(defmethod t/transport :kafka
+(deftransport :kafka
   [{:keys [config topics]}]
   (let [serdes        (serde-map topics)
         test-consumer (consumer config topics (get serdes :deserializers))

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -3,7 +3,7 @@
    [clojure.tools.logging :as log]
    [jackdaw.client :as kafka]
    [jackdaw.test.journal :as j]
-   [jackdaw.test.transports :as t]
+   [jackdaw.test.transports :as t :refer [deftransport]]
    [jackdaw.test.serde :refer [byte-array-serializer byte-array-deserializer
                                apply-serializers apply-deserializers serde-map]]
    [manifold.stream :as s]
@@ -132,8 +132,7 @@
                    (log/infof "stopped mock producer: %s" {:driver driver})))))
     {:messages messages}))
 
-
-(defmethod t/transport :mock
+(deftransport :mock
   [{:keys [driver topics]}]
   (let [serdes        (serde-map topics)
         test-consumer (mock-consumer driver topics (get serdes :deserializers))

--- a/src/jackdaw/test/transports/rest_proxy.clj
+++ b/src/jackdaw/test/transports/rest_proxy.clj
@@ -7,7 +7,7 @@
    [jackdaw.client :as kafka]
    [jackdaw.test.commands :as cmd]
    [jackdaw.test.journal :as j]
-   [jackdaw.test.transports :as t]
+   [jackdaw.test.transports :as t :refer [deftransport]]
    [jackdaw.test.serde :refer :all]
    [jackdaw.test.transports.kafka :refer [mk-producer-record]]
    [manifold.stream :as s]
@@ -283,7 +283,7 @@
      {:producer  producer
       :messages  messages})))
 
-(defmethod t/transport :confluent-rest-proxy
+(deftransport :confluent-rest-proxy
   [{:keys [config topics]}]
   (let [serdes        (serde-map topics)
         test-consumer (rest-proxy-consumer config topics (get serdes :deserializers))

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -96,6 +96,12 @@
           (is (= :ok (:status (first results))))
           (is (= :error (:status (second results)))))))))
 
+(deftest test-empty-test
+  (with-open [t (jd.test/test-machine (kafka-transport))]
+    (let [{:keys [results journal]} (jd.test/run-test t [])]
+      (is (= {:topics {}} journal))
+      (is (= [] results)))))
+
 (deftest test-write-then-watch
   (testing "write then watch"
     (fix/with-fixtures [(fix/topic-fixture kafka-config {"foo" foo-topic})]

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -8,8 +8,6 @@
    [jackdaw.test.fixtures :as fix]
    [jackdaw.test.serde :as serde]
    [jackdaw.test.transports :as trns]
-   [jackdaw.test.transports.kafka]
-   [jackdaw.test.transports.mock]
    [jackdaw.test.middleware :refer [with-status]])
   (:import
    (java.util Properties)
@@ -154,3 +152,10 @@
               (is (= {:id "msg3" :payload "you only live twice"}
                      (-> ((by-id "foo" "msg3") journal)
                          :value))))))))))
+
+(deftest test-transports-loaded
+  (let [transports (trns/supported-transports)]
+    (is (contains? transports :identity))
+    (is (contains? transports :kafka))
+    (is (contains? transports :mock))
+    (is (contains? transports :confluent-rest-proxy))))


### PR DESCRIPTION
Fixes a few bugs I've found recently in the test-machine..

  1. make sure all supported transports are loaded
  2. given an empty test, `run-test` tries to run the "first" command even if no such command exists