### PR TITLE
Imported jackdaw.serdes namespace to resolver

### DIFF
--- a/src/jackdaw/serdes/resolver.clj
+++ b/src/jackdaw/serdes/resolver.clj
@@ -5,6 +5,7 @@
             [jackdaw.serdes.avro.confluent]
             [jackdaw.serdes.edn]
             [jackdaw.serdes.json]
+            [jackdaw.serdes]
             [jackdaw.specs]))
 
 (defn load-schema


### PR DESCRIPTION
When we attempt to use the jackdaw resolver with the keyword
`:jackdaw.serdes/string-serde`, the keyword cannot be resolved into the 
serde function it is supposed to be. So we import the namespace into the resolver.