### PR TITLE
Use lein-tool-deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,13 @@
+{:mvn/repos {"confluent" {:url "https://packages.confluent.io/maven/"}}
+ :deps {aleph {:mvn/version "0.4.6"}
+        clj-time {:mvn/version "0.15.1"}
+        danlentz/clj-uuid {:mvn/version "0.1.7"}
+        io.confluent/kafka-schema-registry-client {:mvn/version "5.1.0"}
+        io.confluent/kafka-avro-serializer {:mvn/version "5.1.0"}
+        org.apache.kafka/kafka-clients {:mvn/version "2.1.0"}
+        org.apache.kafka/kafka-streams {:mvn/version "2.1.0"}
+        org.apache.kafka/kafka_2.11 {:mvn/version "2.1.0"}
+        org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/data.json {:mvn/version "0.2.6"}
+        org.clojure/tools.logging {:mvn/version "0.4.1"}
+        org.clojure/core.cache {:mvn/version "0.7.2"}}}

--- a/project.clj
+++ b/project.clj
@@ -7,25 +7,12 @@
 
   :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
 
-  :dependencies [[aleph "0.4.6"]
-                 [clj-time "0.15.1"]
-                 [danlentz/clj-uuid "0.1.7"]
-                 ;; Confluent does paired releases with Kafka, this should tie
-                 ;; off with the kafka version.
-                 ;; See https://docs.confluent.io/current/release-notes.html
-
-                 [io.confluent/kafka-schema-registry-client "5.1.0"]
-                 [io.confluent/kafka-avro-serializer "5.1.0"]
-                 [org.apache.kafka/kafka-clients "2.1.0"]
-                 [org.apache.kafka/kafka-streams "2.1.0"]
-                 [org.apache.kafka/kafka_2.11 "2.1.0"]
-                 [org.clojure/clojure "1.9.0" :scope "provided"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/core.cache "0.7.2"]]
-
   :aot [jackdaw.serdes.fn-impl jackdaw.serdes.edn]
-  :plugins [[me.arrdem/lein-git-version "2.0.8"]]
+  :plugins [[me.arrdem/lein-git-version "2.0.8"]
+            [lein-tools-deps "0.4.3"]]
+
+  :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
+  :lein-tools-deps/config {:config-files [:install :user :project]}
 
   :git-version
   {:status-to-version


### PR DESCRIPTION
Use this project to allow a smoother transition to deps.edn
https://github.com/RickMoynihan/lein-tools-deps

Only dependencies information are moved into deps.edn, all the rest stays in project.clj