### PR TITLE
Fix typo in service-ready? fixture

### DIFF
--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -158,7 +158,7 @@
   (fn [t]
     (let [ok? (fn [x]
                 (and (not (= :timeout x))
-                     (= (:status 200))))
+                     (= 200 (:status x))))
 
           ready-check @(d/timeout!
                         (d/future


### PR DESCRIPTION
This fixes a typo in the 2nd condition of the `service-ready?` fixture which could cause the service to be declared ready before it is actually responding with an HTTP code of 200.

This might be what is causing the rest-proxy test to sometimes fail due to commencing the test before the service is properly ready.