### PR TITLE
Hackathon fixes

### DIFF
--- a/src/jackdaw/test/commands/write.clj
+++ b/src/jackdaw/test/commands/write.clj
@@ -53,7 +53,6 @@
      (let [to-send (create-message topic-map message opts)
            messages (:messages (:producer machine))
            ack (promise)]
-       (log/info "Sending" to-send "to topic" topic-name)
        (s/put! messages (assoc to-send :ack ack))
        (deref ack (:timeout opts 1000) {:error :timeout}))
      {:error :unknown-topic

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -82,9 +82,9 @@
   ([{:keys [topic-name]} key value]
    (ProducerRecord. ^String topic-name key value))
   ([{:keys [topic-name]} partition key value]
-   (ProducerRecord. ^String topic-name ^Integer partition key value))
+   (ProducerRecord. ^String topic-name ^Integer (int partition) key value))
   ([{:keys [topic-name]} partition timestamp key value]
-   (ProducerRecord. ^String topic-name ^Integer partition ^Long timestamp key value)))
+   (ProducerRecord. ^String topic-name ^Integer (int partition) ^Long timestamp key value)))
 
 (defn consumer
   "Creates an asynchronous Kafka Consumer of all topics defined in the

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -159,7 +159,6 @@
   ([kafka-config topic-config serializers]
    (let [producer       (kafka/producer kafka-config byte-array-serde)
          messages       (s/stream 1 (map (fn [x]
-                                           (log/info "producing: " x)
                                            (try
                                              (-> (apply-serializers serializers x)
                                                  (build-record))


### PR DESCRIPTION
There are some old logging statements that make tests which produce lots of data overly verbose. And  the test-producer should cast the partition to an int.