### PR TITLE
Resolve dependency conflicts reported by lein deps :tree

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,14 @@
 
   :dependencies [[aleph "0.4.6"]
                  [clj-time "0.15.1"]
-                 [danlentz/clj-uuid "0.1.7"]
+                 [danlentz/clj-uuid "0.1.7"
+                  :exclusions [primitive-math]]
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.
                  ;; See https://docs.confluent.io/current/release-notes.html
 
-                 [io.confluent/kafka-schema-registry-client "5.1.2"]
+                 [io.confluent/kafka-schema-registry-client "5.1.2"
+                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
                  [io.confluent/kafka-avro-serializer "5.1.2"]
                  [org.apache.kafka/kafka-clients "2.2.0"]
                  [org.apache.kafka/kafka-streams "2.2.0"]


### PR DESCRIPTION
`lein deps :tree` reports a few warnings about dependency conflicts and these warnings typically propagate through to projects that use jackdaw so it's good to fix here if possible.

The main warnings were...

```
[danlentz/clj-uuid "0.1.7"] -> [primitive-math "0.1.4"]
 overrides
[aleph "0.4.6"] -> [byte-streams "0.2.4"] -> [primitive-math "0.1.6"]
```

and 

```
[io.confluent/kafka-schema-registry-client "5.1.2"] -> [com.fasterxml.jackson.core/jackson-databind "2.9.6"]
 overrides
[org.apache.kafka/kafka-streams-test-utils "2.2.0"] -> [org.apache.kafka/kafka-streams "2.2.0"] -> [org.apache.kafka/connect-json "2.2.0" :exclusions [*/javax.ws.rs-api]] -> [com.fasterxml.jackson.datatype/jackson-datatype-jdk8 "2.9.8"] -> [com.fasterxml.jackson.core/jackson-databind "2.9.8"]
```

This PR just adds exclusions so that the later versions are used in both cases.