### PR TITLE
Make sure mock driver is properly closed after use

### DIFF
--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -147,6 +147,7 @@
      :serdes serdes
      :topics topics
      :exit-hooks [(fn []
+                    (.close driver)
                     (s/close! (:messages test-producer))
                     (reset! (:continue? test-consumer) false)
                     @(:process test-consumer))]}))

--- a/test/jackdaw/test/transports/mock_test.clj
+++ b/test/jackdaw/test/transports/mock_test.clj
@@ -70,8 +70,21 @@
       (log/info "completed" test-id)
       result)))
 
+(deftest test-driver-closed-after-use
+  (let [driver-closed? (atom false)
+        driver (reify java.io.Closeable
+                 (close [this]
+                   (reset! driver-closed? true)))
+        transport (trns/transport {:type :mock
+                                   :driver driver
+                                   :topics {}})]
+    (with-open [machine (jd.test/test-machine transport)]
+      (is (not @driver-closed?)))
+
+    (is @driver-closed?)))
+
 (deftest test-mock-transport
-  (with-mock-transport {:test-id "test-mock-transport"}
+  (with-mock-transport {:test-id "test-mock"}
     (fn [t]
       (let [msg {:id 1 :payload "foo"}
             topic test-in
@@ -93,7 +106,7 @@
           (is (integer? (:offset result))))))))
 
 (deftest test-mock-transport-with-journal
-  (with-mock-transport {:test-id "test-mock-transport-with-journal"}
+  (with-mock-transport {:test-id "test-mock"}
     (fn [t]
       (let [msg {:id 1 :payload "foo"}
             topic test-in


### PR DESCRIPTION
I think this should fix the issue with the word-count demo found by @matthias-margush https://github.com/FundingCircle/jackdaw/issues/114#issuecomment-486337672. The problem was that the `TopologyTestDriver` was not being closed along with all the other test resources. We just had to add it to the `:exit-hooks` for the mock transport.