### PR TITLE
Adds wrappers for reduce & aggregate arities with implicit key value stores

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -247,10 +247,12 @@
 
 (defn aggregate
   "Aggregates values by key into a new KTable."
+  ([kgrouped initializer-fn adder-fn]
+   (p/aggregate kgrouped initializer-fn adder-fn))
+  ([kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config]
+   (p/aggregate kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config))
   ([kgrouped initializer-fn adder-fn subtractor-fn topic-config]
-   (p/aggregate kgrouped initializer-fn adder-fn subtractor-fn topic-config))
-  ([kgrouped initializer-fn aggregator-fn topic-config]
-   (p/aggregate kgrouped initializer-fn aggregator-fn topic-config)))
+   (p/aggregate kgrouped initializer-fn adder-fn subtractor-fn topic-config)))
 
 (defn count
   "Counts the number of records by key into a new KTable."
@@ -263,8 +265,10 @@
   "Combines values of a stream by key into a new KTable."
   ([kgrouped adder-fn subtractor-fn topic-config]
    (p/reduce kgrouped adder-fn subtractor-fn topic-config))
-  ([kgrouped reducer-fn topic-config]
-   (p/reduce kgrouped reducer-fn topic-config)))
+  ([kgrouped reducer-fn subtractor-fn-or-topic-config]
+   (p/reduce kgrouped reducer-fn subtractor-fn-or-topic-config))
+  ([kgrouped reducer-fn]
+   (p/reduce kgrouped reducer-fn)))
 
 ;; IKGroupedTable
 

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -385,6 +385,12 @@
      config
      (aggregate kgroupedtable initializer-fn adder-fn subtractor-fn topic-config)))
 
+  (aggregate
+    [_ initializer-fn adder-fn subtractor-fn]
+    (configured-ktable
+     config
+     (aggregate kgroupedtable initializer-fn adder-fn subtractor-fn)))
+
   (count
     [_]
     (configured-ktable
@@ -402,6 +408,12 @@
     (configured-ktable
      config
      (reduce kgroupedtable adder-fn subtractor-fn topic-config)))
+
+  (reduce
+    [_ adder-fn subtractor-fn]
+    (configured-ktable
+     config
+     (reduce kgroupedtable adder-fn subtractor-fn)))
 
   IKGroupedTable
   (kgroupedtable*
@@ -430,6 +442,12 @@
      config
      (aggregate kgroupedstream initializer-fn aggregator-fn topic-config)))
 
+  (aggregate
+    [_ initializer-fn aggregator-fn]
+    (configured-ktable
+     config
+     (aggregate kgroupedstream initializer-fn aggregator-fn)))
+
   (count
     [_]
     (configured-ktable
@@ -448,18 +466,24 @@
      config
      (reduce kgroupedstream reducer-fn topic-config)))
 
+  (reduce
+    [_ reducer-fn]
+    (configured-ktable
+     config
+     (reduce kgroupedstream reducer-fn)))
+
   IKGroupedStream
   (windowed-by-time
     [_ windows]
     (configured-time-windowed-kstream
-      config
-      (windowed-by-time kgroupedstream windows)))
+     config
+     (windowed-by-time kgroupedstream windows)))
 
   (windowed-by-session
     [_ windows]
     (configured-session-windowed-kstream
-      config
-      (windowed-by-session kgroupedstream windows)))
+     config
+     (windowed-by-session kgroupedstream windows)))
 
   (kgroupedstream*
     [_]
@@ -495,6 +519,12 @@
     (configured-ktable
      config
      (reduce kgroupedstream reducer-fn topic-config)))
+
+  (reduce
+    [_ reducer-fn]
+    (configured-ktable
+     config
+     (reduce kgroupedstream reducer-fn)))
 
   ITimeWindowedKStream
   (time-windowed-kstream*

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -437,6 +437,14 @@
                  ^Aggregator (aggregator subtractor-fn)
                  (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
 
+  (aggregate
+    [_ initializer-fn adder-fn subtractor-fn]
+    (clj-ktable
+     (.aggregate ^KGroupedTable kgroupedtable
+                 ^Initializer (initializer initializer-fn)
+                 ^Aggregator (aggregator adder-fn)
+                 ^Aggregator (aggregator subtractor-fn))))
+
   (count
     [_]
     (clj-ktable
@@ -455,6 +463,13 @@
               ^Reducer (reducer adder-fn)
               ^Reducer (reducer subtractor-fn)
               ^Materialized (topic->materialized topic-config))))
+
+  (reduce
+    [_ adder-fn subtractor-fn]
+    (clj-ktable
+     (.reduce ^KGroupedTable kgroupedtable
+              ^Reducer (reducer adder-fn)
+              ^Reducer (reducer subtractor-fn))))
 
   IKGroupedTable
   (kgroupedtable*
@@ -476,6 +491,13 @@
                  ^Aggregator (aggregator aggregator-fn)
                  (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
 
+  (aggregate
+    [_ initializer-fn aggregator-fn]
+    (clj-ktable
+     (.aggregate ^KGroupedStream kgroupedstream
+                 ^Initializer (initializer initializer-fn)
+                 ^Aggregator (aggregator aggregator-fn))))
+
   (count
     [_]
     (clj-ktable
@@ -493,6 +515,12 @@
      (.reduce ^KGroupedStream kgroupedstream
               ^Reducer (reducer reducer-fn)
               ^Materialized (topic->materialized topic-config))))
+
+  (reduce
+    [_ reducer-fn]
+    (clj-ktable
+     (.reduce ^KGroupedStream kgroupedstream
+              ^Reducer (reducer reducer-fn))))
 
   IKGroupedStream
   (windowed-by-time

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -200,7 +200,8 @@
   "Methods shared between `IKGroupedTable` and `IKGroupedStream`."
   (aggregate
     [kgrouped initializer-fn adder-fn subtractor-fn topic-config]
-    [kgrouped initializer-fn aggregator-fn topic-config]
+    [kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config]
+    [kgrouped initializer-fn aggregator-fn]
     "Aggregates values by key into a new KTable.")
 
   (count
@@ -210,7 +211,8 @@
 
   (reduce
     [kgrouped adder-fn subtractor-fn topic-config]
-    [kgrouped reducer-fn topic-config]
+    [kgrouped reducer-fn subtractor-fn-or-topic-config]
+    [kgrouped reducer-fn]
     "Combines values of a stream by key into a new KTable."))
 
 (defprotocol IKGroupedTable

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -273,7 +273,7 @@
                      :initializer-fn ::lambdas/initializer-fn
                      :adder-fn ::lambdas/aggregator-fn
                      :subtractor-fn (s/? ::lambdas/aggregator-fn)
-                     :topic-config ::topic-config)
+                     :topic-config (s/? ::topic-config))
         :ret ktable?)
 
 (s/fdef k/count
@@ -285,7 +285,7 @@
         :args (s/cat ::kgrouped ::kgroupedstream-or-kgroupedtable
                      :adder-or-reducer-fn ifn?
                      :subtractor-fn (s/? ifn?)
-                     :topic-config ::topic-config)
+                     :topic-config (s/? ::topic-config))
         :ret ktable?)
 
 ;; IKGroupedTable


### PR DESCRIPTION
Wraps these new arities of `aggregate` and `reduce`:

* [KGroupedTable.aggregate](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KGroupedTable.html#aggregate-org.apache.kafka.streams.kstream.Initializer-org.apache.kafka.streams.kstream.Aggregator-org.apache.kafka.streams.kstream.Aggregator-)

* [KGroupedTable.reduce](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KGroupedTable.html#reduce-org.apache.kafka.streams.kstream.Reducer-org.apache.kafka.streams.kstream.Reducer-)

* [KGroupedStream.aggregate](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KGroupedStream.html#aggregate-org.apache.kafka.streams.kstream.Initializer-org.apache.kafka.streams.kstream.Aggregator-)

* [KGroupedSteam.reduce](https://kafka.apache.org/20/javadoc/org/apache/kafka/streams/kstream/KGroupedStream.html#reduce-org.apache.kafka.streams.kstream.Reducer-)