### PR TITLE
Contributing Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,47 +4,55 @@
 
 ### Added
 
- * start keeping a changelog (#122)
- * added test-machine example to the word-count example application (#120)
+ * Add changelog and contributing files (#122)
+ * Add test-machine example to the word-count example application (#120)
 
 ### Changed
 
- * make the test for the rest-proxy transport use keywords to identify topics (#120)
- * fix a typo in the `service-ready?` test fixture (#121)
- * ensure that any user-supplied partitions are cast to `int` before handing
+ * Ensure user-supplied partitions are cast to `int` before handing
    them to the underlying kafka producer (#124)
+ * Make the test for the rest-proxy transport use keywords to identify topics (#120)
+ * Resolve dependency conflict reported by lein deps :tree (#125)
+ * Fix a typo in the `service-ready?` test fixture (#121)
+ * Make sure mock dirver is closed after use (#128)
+ * Fix Jackdaw version for Word Count example (#131)
+ * Add new arrities for aggregate and reduce (#132)
 
 ### Removed
 
- * deleted a couple of overly verbose logging statements (#124)
+ * Delete a couple of overly verbose logging statements (#124)
+
 
 ## [0.6.3] - [2019-03-28]
 
 ### Added
 
+None
+
 ### Changed
 
- * upgraded Kafka dependency to 2.2.0 (#123)
+ * Upgrade Kafka dependency to 2.2.0 (#123)
 
 ### Removed
 
-## [0.6.2] - [2019-03-21]
+None
 
-Work continues on improving the documentation/examples and improving upstream API coverage.
+
+## [0.6.2] - [2019-03-21]
 
 ### Added
 
- * improvement and clarification of documentation (on-going) (#116, #117, #118)
- * support for including a literal avro schema in the topic definitions resolved by the default resolver (#109)
- * support for including a custom :partition-fn in kafka streams operations that write records (#103)
+ * Improvement and clarification of documentation (on-going) (#116, #117, #118)
+ * Support for including a literal avro schema in the topic definitions resolved by the default resolver (#109)
+ * Support for including a custom :partition-fn in kafka streams operations that write records (#103)
 
 ### Changed
 
- * implement kibit recommendations (#118)
- * word-count example (#108)
-   - log to file instead of stdout
-   - a few simplifications in the implementation
- * in the streams mock driver, get-records now returns a vector of "datafied" producer-records rather than simply the k,v pairs (part of #103)
+ * Implement kibit recommendations (#118)
+ * Word-count example (#108)
+   - Log to file instead of stdout
+   - A few simplifications in the implementation
+ * In the streams mock driver, get-records now returns a vector of "datafied" producer-records rather than simply the k,v pairs (part of #103)
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ of software distributed by Funding Circle, you reserve all right, title, and
 interest in and to your contributions. All contributions are subject to the
 following DCO + License terms.
 
-[DCO + License][9]
+[DCO + License][1]
 
 If you discover issues, have ideas for improvements or new features,
-please report them to the [issue tracker][1] of the repository or
+please report them to the [issue tracker][2] of the repository or
 submit a pull request. Please, try to follow these guidelines when you
 do so.
 
@@ -28,28 +28,30 @@ do so.
 ### Reporting bugs
 
 When reporting bugs it's a good idea to go through the [Troubleshooting section
-of the manual][7].  Adding information like the backtrace and any sample messages
+of the manual][8].  Adding information like the backtrace and any sample messages
 and/or topic configurations used to the bug report makes it easier to track down bugs.
 Some steps to reproduce a bug reliably would also make a huge difference.
 
 ## Pull requests
 
-* Read [how to properly contribute to open source projects on Github][2].
-* Keep style and feature PRs separate. Feel free to discuss proposals in #jackdaw[8]
+* Read [how to properly contribute to open source projects on Github][3].
+* Keep style and feature PRs separate. Feel free to discuss proposals in #jackdaw[9]
 * Make sure that the unit tests are passing (`lein test`).
-* Write [good commit messages][3] and sign each commit (`git commit -s -m 'Added foo feature'`).
+* Write [good commit messages][4] and sign each commit (`git commit -s -m 'Add foo feature'`).
 * Mention related tickets in the commit messages (e.g. `[Fix #N] Add command ...`).
-* Update the [changelog][6].
-* [Squash related commits together][5].
-* Open a [pull request][4] that relates to *only* one subject with a clear title
+* Update the [changelog][7].
+* [Squash related commits together][6].
+* Open a [pull request][5] that relates to *only* one subject with a clear title
   and description in grammatically correct, complete sentences.
+* [Sign off][10] on all commits, which certifies that you agree to the [DCO + License][1].
 
-[1]: https://github.com/FundingCircle/jackdaw/issues
-[2]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
-[3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
-[4]: https://help.github.com/articles/using-pull-requests
-[5]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
-[6]: https://github.com/FundingCircle/jackdaw/blob/master/CHANGELOG.md
-[7]: https://github.com/FundingCircle/jackdaw/blob/master/doc/trouble-shooting.md
-[8]: https://clojurians.slack.com/messages/CEA3C7UG0/
-[9]: https://github.com/FundingCircle/jackdaw/tree/master/doc/DCO_+_LICENSE
+[1]: https://github.com/FundingCircle/jackdaw/tree/master/doc/DCO_+_LICENSE
+[2]: https://github.com/FundingCircle/jackdaw/issues
+[3]: http://gun.io/blog/how-to-github-fork-branch-and-pull-request
+[4]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[5]: https://help.github.com/articles/using-pull-requests
+[6]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
+[7]: https://github.com/FundingCircle/jackdaw/blob/master/CHANGELOG.md
+[8]: https://github.com/FundingCircle/jackdaw/blob/master/doc/trouble-shooting.md
+[9]: https://clojurians.slack.com/messages/CEA3C7UG0/
+[10]: https://www.kernel.org/doc/html/v4.17/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin


### PR DESCRIPTION
`CHANGELOG.md`:
* Deletes the release summary from `0.6.2`
* Capitalizes list items
* Adds missing items so we can release
* Adjusts order to reflect history

`CONTRIBUTING.md`:
* Moves `.github/CONTRIBUTING` to `CONTRIBUTING.md`
* Changes PR commit example to imperative form ("add", not "added")
* Updates numbers to match order in which links appear
* Adds sign-off step and link