### PR TITLE
Include kafka-streams-test-utils so jackdaw users don't have to

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,6 +21,7 @@
                  [org.apache.kafka/kafka-clients "2.2.0"]
                  [org.apache.kafka/kafka-streams "2.2.0"]
                  [org.apache.kafka/kafka_2.11 "2.2.0"]
+                 [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
                  [org.clojure/clojure "1.9.0" :scope "provided"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.logging "0.4.1"]


### PR DESCRIPTION
Users wishing to use the mock topology test driver currently have to explicitly depend on org.apache.kafka/kafka-streams-test-utils or else they run into ClassNotFound exceptions.