### PR TITLE
Add more test machine commands for inspecting its state

### DIFF
--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -100,7 +100,16 @@ specific arguments. Currently the following commands are the supported.
   :sleep    [sleep-ms]           Sleeps for `sleep-ms` milliseconds
   :println  [args]               Prints the supplied args to stdout
   :pprint   [args]               Pretty prints the supplied args to stdout
-  :do       [f]                  Execute arbitrary function
+  :do       [f]                  Execute arbitrary function. The function should take
+                                 a single argument, and will be passed the journal
+                                 state (content of the journal atom).
+  :do!      [f]                  Execute arbitrary function. The function should take
+                                 a single argument, and will be passed the journal
+                                 atom itself. Allows monitoring of the joural or
+                                 the like to be injected.
+  :inspect  [f]                  A debugging command, again executes an arbitrary
+                                 function of a single argument. This function will
+                                 be passed the entire test machine state.
 ```
 
 ### Test Results

--- a/src/jackdaw/test/commands/base.clj
+++ b/src/jackdaw/test/commands/base.clj
@@ -15,4 +15,10 @@
               (pprint/pprint params))
 
    :do (fn [machine cmd [do-fn]]
-         (do-fn @(:journal machine)))})
+         (do-fn @(:journal machine)))
+
+   :do! (fn [machine cmd [do-fn]]
+          (do-fn (:journal machine)))
+
+   :inspect (fn [machine cmd [inspect-fn]]
+              (inspect-fn machine))})

--- a/test/jackdaw/test/commands/base_test.clj
+++ b/test/jackdaw/test/commands/base_test.clj
@@ -31,5 +31,19 @@
           machine {:journal journal}
           do-fn (fn [j]
                   (is (= j @journal)))]
-      ((cmd/command-map :do) machine nil [do-fn]))))
+      ((cmd/command-map :do) machine nil [do-fn])))
+
+  (testing "do!"
+    (let [journal (agent {})
+          machine {:journal journal}
+          do-fn (fn [j]
+                  (is (= j journal)))]
+      ((cmd/command-map :do!) machine nil [do-fn])))
+
+  (testing "inspect"
+    (let [journal (agent {})
+          machine {:journal journal}
+          do-fn (fn [m]
+                  (is (= m machine)))]
+      ((cmd/command-map :inspect) machine nil [do-fn]))))
 


### PR DESCRIPTION
Added two new Test Machine commands.

`:do!` - like `do` but the function provided is passed the journal atom, not the contents of the journal atom.

`:inspect` - the function provided is passed the whole test machine state (a debugging hook)