### PR TITLE
Add merger for session window aggregation

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -251,8 +251,8 @@
    (p/aggregate kgrouped initializer-fn adder-fn))
   ([kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config]
    (p/aggregate kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config))
-  ([kgrouped initializer-fn adder-fn subtractor-fn topic-config]
-   (p/aggregate kgrouped initializer-fn adder-fn subtractor-fn topic-config)))
+  ([kgrouped initializer-fn adder-fn subtractor-or-merger-fn topic-config]
+   (p/aggregate kgrouped initializer-fn adder-fn subtractor-or-merger-fn topic-config)))
 
 (defn count
   "Counts the number of records by key into a new KTable."

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -539,10 +539,10 @@
 (deftype ConfiguredSessionWindowedKStream [config kgroupedstream]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn aggregator-fn topic-config]
+    [_ initializer-fn aggregator-fn merger-fn topic-config]
     (configured-ktable
      config
-     (aggregate kgroupedstream initializer-fn aggregator-fn topic-config)))
+     (aggregate kgroupedstream initializer-fn aggregator-fn merger-fn topic-config)))
 
   (count
     [_]

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -18,7 +18,7 @@
            [org.apache.kafka.streams.kstream
             Aggregator Consumed GlobalKTable Initializer Joined
             JoinWindows KGroupedStream KGroupedTable KStream KTable
-            KeyValueMapper Materialized Predicate Printed Produced
+            KeyValueMapper Materialized Merger Predicate Printed Produced
             Reducer Serialized SessionWindowedKStream SessionWindows
             TimeWindowedKStream ValueJoiner ValueMapper
             ValueMapperWithKey ValueTransformerSupplier Windows]
@@ -583,11 +583,12 @@
 (deftype CljSessionWindowedKStream [^SessionWindowedKStream windowed-kstream]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn aggregator-fn {:keys [topic-name value-serde]}]
+    [_ initializer-fn aggregator-fn merger-fn {:keys [topic-name value-serde]}]
     (clj-ktable
      (.aggregate ^SessionWindowedKStream windowed-kstream
                  ^Initializer (initializer initializer-fn)
                  ^Aggregator (aggregator aggregator-fn)
+                 ^Merger (merger merger-fn)
                  (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
 
   (count

--- a/src/jackdaw/streams/lambdas.clj
+++ b/src/jackdaw/streams/lambdas.clj
@@ -4,7 +4,7 @@
   (:import org.apache.kafka.streams.KeyValue
            [org.apache.kafka.streams.kstream
             Aggregator ForeachAction Initializer KeyValueMapper
-            Predicate Reducer TransformerSupplier ValueJoiner
+            Merger Predicate Reducer TransformerSupplier ValueJoiner
             ValueMapper ValueTransformerSupplier]
            [org.apache.kafka.streams.processor
             Processor ProcessorSupplier StreamPartitioner]))
@@ -78,6 +78,16 @@
   single parameter, and returns a list of `[key value]`."
   [key-value-flatmapper-fn]
   (FnKeyValueFlatMapper. key-value-flatmapper-fn))
+
+(deftype FnMerger [merger-fn]
+  Merger
+  (apply [this agg-key aggregate1 aggregate2]
+    (merger-fn agg-key aggregate1 aggregate2)))
+
+(defn merger
+  "Packages up a Clojure fn in a kstream merger (merges together two SessionWindows aggregate values)."
+  ^Merger [merger-fn]
+  (FnMerger. merger-fn))
 
 (deftype FnPredicate [predicate-fn]
   Predicate

--- a/src/jackdaw/streams/lambdas/specs.clj
+++ b/src/jackdaw/streams/lambdas/specs.clj
@@ -4,13 +4,15 @@
   (:require [clojure.spec.alpha :as s]
             [jackdaw.streams.lambdas :as lambdas])
   (:import [org.apache.kafka.streams.kstream
-            Aggregator Initializer]))
+            Aggregator Initializer Merger]))
 
 (def initializer? (partial instance? Initializer))
 (def aggregator? (partial instance? Aggregator))
+(def merger? (partial instance? Merger))
 
 (s/def ::lambdas/initializer-fn ifn?)
 (s/def ::lambdas/aggregator-fn ifn?)
+(s/def ::lambdas/merger-fn ifn?)
 
 (s/fdef lambdas/initializer
         :args (s/cat :initializer-fn ::lambdas/initializer-fn)
@@ -19,3 +21,7 @@
 (s/fdef lambdas/aggregator
         :args (s/cat :aggregator-fn ::lambdas/aggregator-fn)
         :ret aggregator?)
+
+(s/fdef lambdas/merger
+        :args (s/cat :merger-fn ::lambdas/merger-fn)
+        :ret merger?)

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -199,7 +199,7 @@
 (defprotocol IKGroupedBase
   "Methods shared between `IKGroupedTable` and `IKGroupedStream`."
   (aggregate
-    [kgrouped initializer-fn adder-fn subtractor-fn topic-config]
+    [kgrouped initializer-fn adder-fn subtractor-or-merger-fn topic-config]
     [kgrouped initializer-fn aggregator-fn subtractor-fn-or-topic-config]
     [kgrouped initializer-fn aggregator-fn]
     "Aggregates values by key into a new KTable.")

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -272,7 +272,7 @@
         :args (s/cat :kgrouped ::kgroupedstream-or-kgroupedtable
                      :initializer-fn ::lambdas/initializer-fn
                      :adder-fn ::lambdas/aggregator-fn
-                     :subtractor-fn (s/? ::lambdas/aggregator-fn)
+                     :subtractor-or-merger-fn (s/? (s/alt ::lambdas/aggregator-fn ::lambdas/merger-fn))
                      :topic-config (s/? ::topic-config))
         :ret ktable?)
 


### PR DESCRIPTION
The `aggregate` method of `SessionWindowedKStream` expects a `Merger`
argument.

If you try to aggregate without the Merger arg, you get this error:
  `org.apache.kafka.streams.kstream.Materialized cannot be cast to org.apache.kafka.streams.kstream.Merger`

In this PR I add a merger to the lambdas namespace and adjust various
signatures to account for the extra argument.

Signed-off-by: Sam Brauer <sbrauer@rentpath.com>