### PR TITLE
Stop swallowing errors in test-machine

### DIFF
--- a/src/jackdaw/test/journal.clj
+++ b/src/jackdaw/test/journal.clj
@@ -20,10 +20,8 @@
         check-condition (fn [new]
                           (when-let [result (condition? new)]
                             (remove-watch journal id)
-                            (if (boolean? result)
-                              (deliver p {:result :found})
-                              (deliver p result))))]
-
+                            (deliver p {:result :found
+                                        :info result})))]
     (add-watch journal id (fn [k r old new]
                             (check-condition new)))
     ;; don't rely on watcher to 'check-condition'

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -156,6 +156,7 @@
                                    :serialized-key-size
                                    :serialized-value-size]))))))
 
+
 (defn producer
   "Creates an asynchronous kafka producer to be used by a test-machine for for
    injecting test messages"

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -1,5 +1,6 @@
 (ns jackdaw.test.transports.mock
   (:require
+   [clojure.stacktrace :as stacktrace]
    [clojure.tools.logging :as log]
    [jackdaw.client :as kafka]
    [jackdaw.test.journal :as j]
@@ -115,22 +116,35 @@
 
 (defn mock-producer
   [driver topic-config serializers on-input]
-  (let [messages (s/stream 1 (comp
-                              (map #(apply-serializers serializers %))
-                              (map (with-input-record topic-config))))]
+  (let [build-record (with-input-record topic-config)
+        messages (s/stream 1 (map (fn [x]
+                                    (try
+                                      (-> (apply-serializers serializers x)
+                                          (build-record))
+                                      (catch Exception e
+                                        (let [trace (with-out-str
+                                                             (stacktrace/print-cause-trace e))]
+                                          (log/error e trace))
+                                        (assoc x :serialization-error e))))))]
 
     (log/infof "started mock producer: %s" {:driver driver})
 
     (d/loop [message (s/take! messages)]
       (d/chain message
-               (fn [{:keys [input-record ack] :as message}]
-                 (if input-record
-                   (do (on-input input-record)
-                       (deliver ack {:topic (.topic input-record)
-                                     :partition (.partition input-record)
-                                     :offset (.offset input-record)})
-                       (d/recur (s/take! messages)))
-                   (log/infof "stopped mock producer: %s" {:driver driver})))))
+        (fn [{:keys [input-record ack serialization-error] :as message}]
+          (cond
+            serialization-error  (do (deliver ack {:error :serialization-error
+                                                   :message (.getMessage serialization-error)})
+                                     (d/recur (s/take! messages)))
+
+            input-record         (do (on-input input-record)
+                                     (deliver ack {:topic (.topic input-record)
+                                                   :partition (.partition input-record)
+                                                   :offset (.offset input-record)})
+                                     (d/recur (s/take! messages)))
+
+            :else (do
+                    (log/infof "stopped mock producer: %s" {:driver driver}))))))
     {:messages messages}))
 
 (deftransport :mock
@@ -138,7 +152,13 @@
   (let [serdes        (serde-map topics)
         test-consumer (mock-consumer driver topics (get serdes :deserializers))
         record-fn     (fn [input-record]
-                        (.pipeInput driver input-record))
+                        (try
+                          (.pipeInput driver input-record)
+                          (catch Exception e
+                            (let [trace (with-out-str
+                                          (stacktrace/print-cause-trace e))]
+                              (log/error e trace))
+                            (throw e))))
         test-producer (when @(:started? test-consumer)
                         (mock-producer driver topics (get serdes :serializers)
                                        record-fn))]

--- a/test/jackdaw/test/transports/kafka_test.clj
+++ b/test/jackdaw/test/transports/kafka_test.clj
@@ -128,13 +128,14 @@
             (is (integer? (:offset result)))))
 
         (testing "the journal is updated"
-          (let [result (watch-for t (fn [journal]
-                                      (->> (get-in journal [:topics "test-out"])
-                                           (filter (fn [m]
-                                                     (= 2 (get-in m [:value :id]))))
-                                           first))
-                                  1000
-                                  "failed to find test-out=2")]
+          (let [result (-> (watch-for t (fn [journal]
+                                          (->> (get-in journal [:topics "test-out"])
+                                               (filter (fn [m]
+                                                         (= 2 (get-in m [:value :id]))))
+                                               first))
+                                      1000
+                                      "failed to find test-out=2")
+                           :info)]
 
             (is (= "test-out" (:topic result)))
             (is (= 2 (:key result)))

--- a/test/jackdaw/test/transports/mock_test.clj
+++ b/test/jackdaw/test/transports/mock_test.clj
@@ -129,13 +129,14 @@
             (is (integer? (:offset result)))))
 
         (testing "the journal is updated"
-          (let [result (watch-for t (fn [journal]
-                                      (->> (get-in journal [:topics "test-out"])
-                                           (filter (fn [m]
-                                                     (= 1 (get-in m [:value :id]))))
-                                           first))
-                                  1000
-                                  "failed to find test-out=2")]
+          (let [result (-> (watch-for t (fn [journal]
+                                          (->> (get-in journal [:topics "test-out"])
+                                               (filter (fn [m]
+                                                         (= 1 (get-in m [:value :id]))))
+                                               first))
+                                      1000
+                                      "failed to find test-out=2")
+                           :info)]
 
             (is (= "test-out" (:topic result)))
             (is (= 1 (:key result)))

--- a/test/jackdaw/test/transports/rest_proxy_test.clj
+++ b/test/jackdaw/test/transports/rest_proxy_test.clj
@@ -145,15 +145,15 @@
             (is (integer? (:offset result)))))
 
         (testing "the journal is updated"
-          (let [result (watch-for t (fn [journal]
-                                      (log/info "jrnl:" journal)
-                                      (->> (get-in journal [:topics :test-out])
-                                           (filter (fn [m]
-                                                     (= 2 (get-in m [:value :id]))))
-                                           first))
-                                  10000
-                                  "failed to find test-out=2")]
-
+          (let [result (-> (watch-for t (fn [journal]
+                                          (log/info "jrnl:" journal)
+                                          (->> (get-in journal [:topics :test-out])
+                                               (filter (fn [m]
+                                                         (= 2 (get-in m [:value :id]))))
+                                               first))
+                                      20000
+                                      "failed to find test-out=2")
+                           :info)]
             (is (= :test-out (:topic result)))
             (is (= 2 (:key result)))
             (is (= {:id 2 :payload "foo"} (:value result)))))))))


### PR DESCRIPTION
When working with the test-machine, it makes for a significantly better developer workflow when any exceptions that occur are bubbled back up to the main thread. Prior versions were catching errors and sometimes not even logging them (mea culpa!).

This PR adds tests with a few of the errors we've seen developers make and ensures that the resulting exception (including the full cause trace) is logged and the exception is bubbled back up to the main thread after all the resources used by the test are torn back down.