### PR TITLE
Rename misnamed global-kstream with global-ktable

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -201,12 +201,12 @@
    (p/transform-values kstream value-transformer-supplier-fn state-store-names)))
 
 (defn join-global
-  [kstream global-kstream kv-mapper joiner]
-  (p/join-global kstream global-kstream kv-mapper joiner))
+  [kstream global-ktable kv-mapper joiner]
+  (p/join-global kstream global-ktable kv-mapper joiner))
 
 (defn left-join-global
-  [kstream global-kstream kv-mapper joiner]
-  (p/left-join-global kstream global-kstream kv-mapper joiner))
+  [kstream global-ktable kv-mapper joiner]
+  (p/left-join-global kstream global-ktable kv-mapper joiner))
 
 (defn merge
   [kstream other]

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -319,18 +319,18 @@
                        ^"[Ljava.lang.String;" (into-array String state-store-names))))
 
   (join-global
-    [_ global-kstream key-value-mapper-fn joiner-fn]
+    [_ global-ktable key-value-mapper-fn joiner-fn]
     (clj-kstream
      (.join kstream
-            ^GlobalKTable (global-ktable* global-kstream)
+            ^GlobalKTable (global-ktable* global-ktable)
             ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
             ^ValueJoiner (value-joiner joiner-fn))))
 
   (left-join-global
-    [_ global-kstream key-value-mapper-fn joiner-fn]
+    [_ global-ktable key-value-mapper-fn joiner-fn]
     (clj-kstream
      (.leftJoin kstream
-                ^GlobalKTable (global-ktable* global-kstream)
+                ^GlobalKTable (global-ktable* global-ktable)
                 ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
                 ^ValueJoiner (value-joiner joiner-fn))))
 


### PR DESCRIPTION
There are 8 references in the code (and code hint in Cursive) to `global-kstream`, that should read `global-ktable` instead.