### PR TITLE
Select matching record from union for coercion during deserialisation.

### DIFF
--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -390,8 +390,12 @@
               field->schema+coercion)))
 
   (match-avro? [_ avro-record]
-    (or (instance? GenericData$Record avro-record)
-        (nil? avro-record)))
+    (cond
+      (nil? avro-record) true
+
+      (instance? GenericData$Record avro-record)
+      (let [^GenericData$Record generic-data-record avro-record]
+        (= schema (.getSchema generic-data-record)))))
 
   (avro->clj [_ avro-record]
     (when avro-record

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -370,6 +370,24 @@
 
 (def complex-schema-str (json/write-str complex-schema))
 
+(deftest correct-union-record-is-picked-for-coercion
+  (let [schema {:type   "record",
+                :name   "myrecord",
+                :fields [{:name "myunion",
+                          :type [{:type   "record",
+                                  :name   "recordtype1",
+                                  :fields [{:name "field1", :type "string"}]}
+                                 {:type   "record",
+                                  :name   "recordtype2",
+                                  :fields [{:name "field2", :type "string"}]}]}]}
+        serde  (->serde (json/write-str schema))]
+
+    (is (= {:myunion {:field1 "hello"}}
+           (round-trip serde "whatever" {:myunion {:field1 "hello"}})))
+
+    (is (= {:myunion {:field2 "hello"}}
+           (round-trip serde "whatever" {:myunion {:field2 "hello"}})))))
+
 (deftest record-serde-test
   (let [serde (->serde complex-schema-str)
         valid-map {:string-field "hello"


### PR DESCRIPTION
During the coercion phase of avro deserialisation, just assuming that a given `GenericData$Record` is the correct one purely on the basis that it is a `GenericData$Record` isn't enough if the record in question is one of several in a union type - the result is that the first record from the union every time.

This PR changes the logic so that the given `Record` only is considered to "match" if the schema itself matches the schema attached to the `Record` by avro itself.