### PR TITLE
delete duplicated test

### DIFF
--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -258,28 +258,6 @@
         (reset! error-raised e)))
     (is @error-raised)))
 
-(deftest test-write-command-error
-  (let [error-raised (atom nil)]
-    (try
-      (jd.test/with-test-machine (trns/transport {:type :mock
-                                                  :driver (jd.test/mock-test-driver (echo-stream test-in test-out)
-                                                                                    {"bootstrap.servers" "localhost:9092"
-                                                                                     "application.id" "test-echo-stream"})
-                                                  :topics {:in test-in
-                                                           :out test-out}})
-        (fn [machine]
-          (jd.test/run-test machine
-                            [[:write! :in {:id "1" :payload "foo"} {:key-fn bad-key-fn}]
-                             [:write! :in {:id "2" :payload "bar"} {:key-fn :id}]
-                             [:watch (fn [journal]
-                                       (->> (get-in journal [:topics :out])
-                                            (filter (fn [r]
-                                                      (= (:id r) "2")))
-                                            (not-empty)))]])))
-      (catch Exception e
-        (reset! error-raised e)))
-    (is @error-raised)))
-
 (deftest test-watch-command-error
   (let [error-raised (atom nil)]
     (try


### PR DESCRIPTION
`test-watch-command-error` is defined in the same way just above.