### PR TITLE
Upgrade clojure to 1.10.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                  [org.apache.kafka/kafka-streams "2.2.0"]
                  [org.apache.kafka/kafka_2.11 "2.2.0"]
                  [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
-                 [org.clojure/clojure "1.9.0" :scope "provided"]
+                 [org.clojure/clojure "1.10.1" :scope "provided"]
                  [org.clojure/data.json "0.2.6"]
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/core.cache "0.7.2"]]
@@ -67,7 +67,7 @@
               ["dev"]
 
               :injections [(require 'io.aviso.logging.setup)]
-              :dependencies [[io.aviso/logging "0.3.1"]
+              :dependencies [[io.aviso/logging "0.3.2"]
                              [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
                              [org.apache.kafka/kafka-clients "2.2.0" :classifier "test"]
                              [org.clojure/test.check "0.9.0"]]}


### PR DESCRIPTION
Jackdaw already requires its users to use 1.10, so it should use it
too.  Aviso logging needed a bump up to avoid a syntax error in
previous 0.3.1.