### PR TITLE
Supply `key-serde` as well as `value-serde` in `aggregate` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.6.7] - [2019-07-24]
+
+### Fixed
+
+ * Supply `key-serde` as well as `value-serde` in `aggregate` methods
+
 ## [0.6.6] - [2019-06-20]
 
 ### Added

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -430,14 +430,13 @@
 (deftype CljKGroupedTable [^KGroupedTable kgroupedtable]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn adder-fn subtractor-fn
-     {:keys [topic-name value-serde]}]
+    [_ initializer-fn adder-fn subtractor-fn topic]
     (clj-ktable
      (.aggregate ^KGroupedTable kgroupedtable
                  ^Initializer (initializer initializer-fn)
                  ^Aggregator (aggregator adder-fn)
                  ^Aggregator (aggregator subtractor-fn)
-                 (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
+                 ^Materialized (topic->materialized topic))))
 
   (aggregate
     [_ initializer-fn adder-fn subtractor-fn]
@@ -486,12 +485,12 @@
 (deftype CljKGroupedStream [^KGroupedStream kgroupedstream]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn aggregator-fn {:keys [topic-name value-serde]}]
+    [_ initializer-fn aggregator-fn topic]
     (clj-ktable
      (.aggregate ^KGroupedStream kgroupedstream
                  ^Initializer (initializer initializer-fn)
                  ^Aggregator (aggregator aggregator-fn)
-                 (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
+                 ^Materialized (topic->materialized topic))))
 
   (aggregate
     [_ initializer-fn aggregator-fn]
@@ -547,12 +546,12 @@
 (deftype CljTimeWindowedKStream [^TimeWindowedKStream windowed-kstream]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn aggregator-fn {:keys [topic-name value-serde]}]
+    [_ initializer-fn aggregator-fn topic]
     (clj-ktable
      (.aggregate ^TimeWindowedKStream windowed-kstream
                  ^Initializer (initializer initializer-fn)
                  ^Aggregator (aggregator aggregator-fn)
-                 (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
+                 ^Materialized (topic->materialized topic))))
 
   (count
     [_]
@@ -585,13 +584,13 @@
 (deftype CljSessionWindowedKStream [^SessionWindowedKStream windowed-kstream]
   IKGroupedBase
   (aggregate
-    [_ initializer-fn aggregator-fn merger-fn {:keys [topic-name value-serde]}]
+    [_ initializer-fn aggregator-fn merger-fn topic]
     (clj-ktable
      (.aggregate ^SessionWindowedKStream windowed-kstream
                  ^Initializer (initializer initializer-fn)
                  ^Aggregator (aggregator aggregator-fn)
                  ^Merger (merger merger-fn)
-                 (doto (Materialized/as ^String topic-name) (.withValueSerde value-serde)))))
+                 ^Materialized (topic->materialized topic))))
 
   (count
     [_]


### PR DESCRIPTION
There's already a `topic->materialized` helper function, which I've
reused.

Signed-off-by: Alexis Lee <alee@greshamtech.com>