### PR TITLE
New feature: Add schema metadata to deserialized avro records

### DIFF
--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -416,7 +416,7 @@
                              [field-key (avro->clj field-coercion value)]))))
               (vals field->schema+coercion))
         {:name (.getName schema)
-         :fullname (.getFullName schema)})))
+         :full-name (.getFullName schema)})))
 
   (clj->avro [_ clj-map path]
     (when-not (map? clj-map)

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -415,8 +415,7 @@
                                                 :entry entry})))
                              [field-key (avro->clj field-coercion value)]))))
               (vals field->schema+coercion))
-        {:name (.getName schema)
-         :full-name (.getFullName schema)})))
+        {:schema schema})))
 
   (clj->avro [_ clj-map path]
     (when-not (map? clj-map)

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -519,7 +519,7 @@
                 :fields [{:name "field1" :type "string"}]}
         serde  (->serde (json/write-str schema))]
 
-    (is (= {:name "MyRecord" :fullname "com.fundingcircle.MyRecord"}
+    (is (= {:name "MyRecord" :full-name "com.fundingcircle.MyRecord"}
            (meta (round-trip serde "whatever" {:field1 "foo"}))))))
 
 (deftest schemaless-test

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -512,6 +512,16 @@
                                                              "topic"
                                                              (uuid/to-string uuid/+null+))))))))
 
+(deftest record-metadata
+  (let [schema {:type "record"
+                :name "MyRecord"
+                :namespace "com.fundingcircle"
+                :fields [{:name "field1" :type "string"}]}
+        serde  (->serde (json/write-str schema))]
+
+    (is (= {:name "MyRecord" :fullname "com.fundingcircle.MyRecord"}
+           (meta (round-trip serde "whatever" {:field1 "foo"}))))))
+
 (deftest schemaless-test
   (let [serde (->serde nil)]
     (is (= (round-trip serde "bananas" "hello")


### PR DESCRIPTION
~~When an Avro record is deserialized to a Clojure map, add the record's name and fully-qualified name to the map as metadata.
These record names are potentially useful info that was being discarded.~~

When an Avro record is deserialized to a Clojure map, add the record's schema to the map as metadata.

My personal use case for this metadata is to make it easier for consuming code to deal with unions of records.