### PR TITLE
[ISSUE-176] allow reset-application-fixture to get bootsrap.servers from app-config

### DIFF
--- a/examples/word-count/test/word_count_test.clj
+++ b/examples/word-count/test/word_count_test.clj
@@ -55,6 +55,14 @@
    :app-config (assoc wc/app-config "cache.max.bytes.buffering" "0")
    :enable? (get-env "BOOTSTRAP_SERVERS")})
 
+(def reset-args
+  "Arguments to pass to the reset action"
+  "--reset-offsets --to-earliest --execute")
+
+(def reset-fn
+  "Function to reset the application"
+  (reset))
+
 (defn props-for [x]
   (doto (Properties.)
     (.putAll (reduce-kv (fn [m k v]
@@ -89,7 +97,7 @@
     (jd.test/mock-transport (mock-transport-config) wc/topic-metadata)))
 
 (deftest test-word-count-example
-  (fix/with-fixtures [(fix/integration-fixture wc/topology-builder test-config)]
+  (fix/with-fixtures [(fix/integration-fixture wc/topology-builder test-config reset-fn reset-args)]
     (jd.test/with-test-machine (test-transport wc/topic-metadata)
       (fn [machine]
         (let [lines ["As Gregor Samsa awoke one morning from uneasy dreams"

--- a/examples/word-count/test/word_count_test.clj
+++ b/examples/word-count/test/word_count_test.clj
@@ -55,14 +55,6 @@
    :app-config (assoc wc/app-config "cache.max.bytes.buffering" "0")
    :enable? (get-env "BOOTSTRAP_SERVERS")})
 
-(def reset-args
-  "Arguments to pass to the reset action"
-  "--reset-offsets --to-earliest --execute")
-
-(def reset-fn
-  "Function to reset the application"
-  (reset))
-
 (defn props-for [x]
   (doto (Properties.)
     (.putAll (reduce-kv (fn [m k v]
@@ -97,7 +89,7 @@
     (jd.test/mock-transport (mock-transport-config) wc/topic-metadata)))
 
 (deftest test-word-count-example
-  (fix/with-fixtures [(fix/integration-fixture wc/topology-builder test-config reset-fn reset-args)]
+  (fix/with-fixtures [(fix/integration-fixture wc/topology-builder test-config)]
     (jd.test/with-test-machine (test-transport wc/topic-metadata)
       (fn [machine]
         (let [lines ["As Gregor Samsa awoke one morning from uneasy dreams"

--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -197,6 +197,8 @@
 ;;; reset-application-fixture ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn reset-application-fixture [app-config reset-fn reset-args]
+  "Reset application with default app-config as well as reset-args,
+   but the fixture can implement custom options"
   (fn [t]
     (let [rt (StreamsResetter.)
           app-id (get app-config "application.id")

--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -234,15 +234,13 @@
   [build-fn {:keys [broker-config
                     topic-metadata
                     app-config
-                    reset-fn
-                    reset-args
                     enable?]}]
   (t/join-fixtures
    (if enable?
      (do
        (log/info "enabled intregration fixtures")
        [(topic-fixture broker-config topic-metadata)
-        (reset-application-fixture app-config reset-fn reset-args)
+        (reset-application-fixture app-config)
         (kstream-fixture {:topology (build-fn topic-metadata)
                           :config app-config})])
      (do

--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -196,28 +196,39 @@
 
 ;;; reset-application-fixture ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn reset-application-fixture [app-config reset-fn reset-args]
+(defn default-reset-fn
+  [rt args]
+  (.run rt (into-array String args)))
+
+(defn reset-application-fixture
   "Reset application with default app-config as well as reset-args,
    but the fixture can implement custom options"
-  (fn [t]
-    (let [rt (StreamsResetter.)
-          app-id (get app-config "application.id")
-          args (->> ["--application-id" (get app-config "application.id")
-                     "--bootstrap-servers" (get app-config "bootstrap.servers")]
-                    (into-array String))
-          result (with-open [out-str (java.io.StringWriter.)
-                             err-str (java.io.StringWriter.)]
-                   (binding [*out* out-str
-                             *err* err-str]
-                     (let [status (reset-fn rt args)]
-                       (flush)
-                       {:status status
-                        :out (str out-str)
-                        :err (str err-str)})))]
-      (if (zero? (:status result))
-        (t)
-        (throw (ex-info "failed to reset application. check logs for details"
-                        result))))))
+  ([app-config]
+   (reset-application-fixture app-config [] default-reset-fn))
+
+  ([app-config reset-args]
+   (reset-application-fixture app-config reset-args default-reset-fn))
+
+  ([app-config reset-args reset-fn]
+   (fn [t]
+     (let [rt (StreamsResetter.)
+           app-id (get app-config "application.id")
+           args (concat ["--application-id" (get app-config "application.id")
+                         "--bootstrap-servers" (get app-config "bootstrap.servers")]
+                        reset-args)
+           result (with-open [out-str (java.io.StringWriter.)
+                              err-str (java.io.StringWriter.)]
+                    (binding [*out* out-str
+                              *err* err-str]
+                      (let [status (reset-fn rt args)]
+                        (flush)
+                        {:status status
+                         :out (str out-str)
+                         :err (str err-str)})))]
+       (if (zero? (:status result))
+         (t)
+         (throw (ex-info "failed to reset application. check logs for details"
+                         result)))))))
 
 (defn integration-fixture
   [build-fn {:keys [broker-config

--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -201,8 +201,8 @@
   (.run rt (into-array String args)))
 
 (defn reset-application-fixture
-  "Reset application with default app-config as well as reset-args,
-   but the fixture can implement custom options"
+  "Returns a fixture that runs the kafka.tools.StreamsResetter with the supplied
+   `reset-args` as parameters"
   ([app-config]
    (reset-application-fixture app-config [] default-reset-fn))
 

--- a/test/jackdaw/test/fixtures_test.clj
+++ b/test/jackdaw/test/fixtures_test.clj
@@ -32,4 +32,56 @@
     (with-open [client (AdminClient/create kafka-config)]
       (is (topic-exists? client topic-foo)))))
 
+(defn test-resetter
+  ""
+  {:style/indent 1}
+  [{:keys [app-config reset-params reset-fn]} assertion-fn]
+  (let [reset-args (atom [])
+        error-data (atom {})
+        test-fn (fn []
+                  (is true "fake test function"))
+        fix-fn (reset-application-fixture app-config reset-params
+                                          (partial reset-fn reset-args))]
 
+    ;; invoke the reset-application fixture with the sample test-fn
+    (try
+      (fix-fn test-fn)
+      (catch Exception e
+        (reset! error-data (ex-data e))))
+
+    (assertion-fn {:resetter (first @reset-args)
+                   :reset-args (second @reset-args)
+                   :error-data @error-data})))
+
+(deftest test-reset-application-fixture
+  (test-resetter {:app-config {"application.id" "yolo"
+                               "bootstrap.servers" "kafka.test:9092"}
+                  :reset-params ["--foo" "foo"
+                                 "--bar" "bar"]
+                  :reset-fn (fn [reset-args rt args]
+                              (reset! reset-args [rt args])
+                              0)}
+    (fn [{:keys [resetter reset-args error-data]}]
+      (is (instance? kafka.tools.StreamsResetter resetter))
+      (is (= ["--application-id" "yolo"
+              "--bootstrap-servers" "kafka.test:9092"
+              "--foo" "foo"
+              "--bar" "bar"]
+             reset-args))
+      (is (empty? error-data)))))
+
+(deftest test-reset-application-fixture-failure
+  (test-resetter {:app-config {"application.id" "yolo"
+                               "bootstrap.servers" "kafka.test:9092"}
+                  :reset-params ["--foo" "foo"
+                                 "--bar" "bar"]
+                  :reset-fn (fn [reset-args rt args]
+                              (reset! reset-args [rt args])
+                              (.write *err* "helpful error message\n")
+                              (.write *out* "essential application info\n")
+                              1)}
+    (fn [{:keys [resetter reset-args error-data]}]
+      (is (instance? kafka.tools.StreamsResetter resetter))
+      (is (= 1 (:status error-data)))
+      (is (= "helpful error message\n" (:err error-data)))
+      (is (= "essential application info\n" (:out error-data))))))


### PR DESCRIPTION
Issue #176 was already fixed by #179 although the fix was not backed by a unit test. @7vs and I (@cddr) had already begun working on this when @kidpollo submitted #179 but figured we'd continue as this PR back-fills a unit-test for the feature and also adds the ability for the user of the fixture to supply optional parameters, and an optional `reset-fn` which allows the unit test to check that the error case is handled with an informative exception (the StreamsResetter quite often fails in a dev environment when the state can easily become inconsistent but the error message usually contains enough information about what to do to resolve the situation.