### PR TITLE
ensure that the command given in exists

### DIFF
--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -18,6 +18,7 @@
   [machine cmd]
   (let [[cmd & params] cmd
         handler (get command-map cmd)]
+
     (if handler
       ;; Happy
       (let [result (handler machine cmd params)]
@@ -26,9 +27,11 @@
                :cmd cmd
                :params params))
       ;; else Sad
-      {:error :unknown-command
-       :cmd cmd
-       :params params})))
+      (throw (ex-info (format "Unknown command: %s" cmd)
+                      {:cmd cmd
+                       :error :unknown-command
+                       :params params
+                       :available-commands (keys command-map)})))))
 
 (defn with-handler
   [machine handler]

--- a/test/jackdaw/test/commands_test.clj
+++ b/test/jackdaw/test/commands_test.clj
@@ -10,5 +10,9 @@
         (is (contains? (-> (cmd/command-handler {} test-cmd)
                            keys
                            set)
-                       k))))))
+                       k)))))
 
+  (testing "Passing an unknown command throws an exception"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Unknown command: :not-found"
+                          (cmd/command-handler {} [:not-found])))))

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -103,6 +103,14 @@
       (is (= {:topics {}} journal))
       (is (= [] results)))))
 
+(deftest test-unknown-command
+  (testing "Passing an unknown command to the machine throws an exception"
+    (with-open [t (jd.test/test-machine (kafka-transport))]
+      (try
+        (jd.test/run-test t [[:not-found]])
+        (catch Exception e
+          (is (= :unknown-command (-> e ex-data :error))))))))
+
 (deftest test-write-then-watch
   (testing "write then watch"
     (fix/with-fixtures [(fix/topic-fixture kafka-config {"foo" foo-topic})]


### PR DESCRIPTION
It's easy to mispell a command, this PR simply throws an exception if any of the commands is unknown to jackdaw.

- throw exception if the command is unknown
- add test