### PR TITLE
no need to pass in the cmd in every command handler

### DIFF
--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -21,7 +21,7 @@
 
     (if handler
       ;; Happy
-      (let [result (handler machine cmd params)]
+      (let [result (handler machine params)]
         (assoc {}
                :result result
                :cmd cmd

--- a/src/jackdaw/test/commands/base.clj
+++ b/src/jackdaw/test/commands/base.clj
@@ -5,20 +5,20 @@
 (def command-map
   {:stop (constantly true)
 
-   :sleep (fn [machine cmd [sleep-ms]]
+   :sleep (fn [machine [sleep-ms]]
             (Thread/sleep sleep-ms))
 
-   :println (fn [machine cmd params]
+   :println (fn [machine params]
               (println (apply str params)))
 
-   :pprint (fn [machine cmd params]
+   :pprint (fn [machine params]
               (pprint/pprint params))
 
-   :do (fn [machine cmd [do-fn]]
+   :do (fn [machine [do-fn]]
          (do-fn @(:journal machine)))
 
-   :do! (fn [machine cmd [do-fn]]
+   :do! (fn [machine [do-fn]]
           (do-fn (:journal machine)))
 
-   :inspect (fn [machine cmd [inspect-fn]]
+   :inspect (fn [machine [inspect-fn]]
               (inspect-fn machine))})

--- a/src/jackdaw/test/commands/watch.clj
+++ b/src/jackdaw/test/commands/watch.clj
@@ -16,7 +16,7 @@
   ([watch-query opts] [watch-query (:info opts) (watch-timeout (:timeout opts))]))
 
 (defn handle-watch-cmd
-  [machine cmd params]
+  [machine params]
   (let [[query info timeout] (apply watch-params params)
         condition? query]
     (j/watch-for machine condition? timeout info)))

--- a/src/jackdaw/test/commands/write.clj
+++ b/src/jackdaw/test/commands/write.clj
@@ -60,7 +60,7 @@
       :known-topics (keys (:topic-config machine))})))
 
 
-(defn handle-write-cmd [machine cmd params]
+(defn handle-write-cmd [machine params]
   (apply do-write machine params))
 
 (def command-map

--- a/test/jackdaw/test/commands/base_test.clj
+++ b/test/jackdaw/test/commands/base_test.clj
@@ -10,13 +10,13 @@
 
   (testing "sleep"
     (let [start (System/currentTimeMillis)
-          _ ((cmd/command-map :sleep) {} nil [1000])
+          _ ((cmd/command-map :sleep) {} [1000])
           end (System/currentTimeMillis)]
       (is (<= 1000 (- end start)))))
 
   (testing "print"
     (is (= "yolo\n"
-           (with-out-str ((cmd/command-map :println) {} nil ["yolo"])))))
+           (with-out-str ((cmd/command-map :println) {} ["yolo"])))))
 
   (testing "pprint"
     (let [d {:a-very-long-key-name-in-a-map
@@ -24,26 +24,25 @@
              :b 2 :c [1 2 3]}
           r (with-out-str (pprint/pprint d))]
       (is (= r
-             (with-out-str ((cmd/command-map :pprint) {} nil d))))))
+             (with-out-str ((cmd/command-map :pprint) {} d))))))
 
   (testing "do"
     (let [journal (agent {})
           machine {:journal journal}
           do-fn (fn [j]
                   (is (= j @journal)))]
-      ((cmd/command-map :do) machine nil [do-fn])))
+      ((cmd/command-map :do) machine [do-fn])))
 
   (testing "do!"
     (let [journal (agent {})
           machine {:journal journal}
           do-fn (fn [j]
                   (is (= j journal)))]
-      ((cmd/command-map :do!) machine nil [do-fn])))
+      ((cmd/command-map :do!) machine [do-fn])))
 
   (testing "inspect"
     (let [journal (agent {})
           machine {:journal journal}
           do-fn (fn [m]
                   (is (= m machine)))]
-      ((cmd/command-map :inspect) machine nil [do-fn]))))
-
+      ((cmd/command-map :inspect) machine [do-fn]))))

--- a/test/jackdaw/test/commands/watch_test.clj
+++ b/test/jackdaw/test/commands/watch_test.clj
@@ -2,8 +2,7 @@
   (:require
    [jackdaw.test.commands.watch :as watch]
    [manifold.deferred :as d]
-   [clojure.test :refer :all]
-   [clojure.tools.logging :as log]))
+   [clojure.test :refer [deftest testing is]]))
 
 ;; An example of the problem the watcher is trying to solve
 ;; might help.
@@ -21,7 +20,7 @@
 (defn run-watch-cmd [watcher cmd-list]
   (let [journal (agent [])
         machine {:journal journal}
-        result-d (d/future (watch/handle-watch-cmd machine :watch [watcher]))]
+        result-d (d/future (watch/handle-watch-cmd machine [watcher]))]
 
     (doseq [cmd (butlast cmd-list)]
       (send journal conj cmd)

--- a/test/jackdaw/test/commands/write_test.clj
+++ b/test/jackdaw/test/commands/write_test.clj
@@ -138,8 +138,8 @@
                                             "bar" bar-topic}})
     (fn [t]
       (testing "valid write"
-        (let [[cmd & params] [:write! "foo" {:id 1 :payload "yolo"}]
-              result (write/handle-write-cmd t cmd params)]
+        (let [[_ & params] [:write! "foo" {:id 1 :payload "yolo"}]
+              result (write/handle-write-cmd t params)]
 
           (testing "returns the kafka record metadata"
             (is (= "foo" (:topic-name result)))
@@ -149,8 +149,8 @@
             (is (contains? result :serialized-value-size)))))
 
       (testing "valid write with explicit key"
-        (let [[cmd & params] [:write! "foo" {:id 1 :payload "yolo"} {:key 101}]
-              result (write/handle-write-cmd t cmd params)]
+        (let [[_ & params] [:write! "foo" {:id 1 :payload "yolo"} {:key 101}]
+              result (write/handle-write-cmd t params)]
 
           (testing "returns the kafka record metadata"
             (is (= "foo" (:topic-name result)))
@@ -161,7 +161,7 @@
 
       (testing "invalid write"
         (testing "serialization failure"
-          (let [[cmd & params] [:write! "bar" {:id 1 :payload "a map is not a number"}]
-                result (write/handle-write-cmd t cmd params)]
+          (let [[_ & params] [:write! "bar" {:id 1 :payload "a map is not a number"}]
+                result (write/handle-write-cmd t params)]
             (is (= :serialization-error (:error result)))
             (is (= "Cannot cast clojure.lang.PersistentArrayMap to java.lang.Long" (:message result)))))))))


### PR DESCRIPTION
The cmd argument was always passed in every handler but never used.
Since you already know what command you are handling you would probably never need it either, so it can be simplified.