### PR TITLE
Better test runner

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,13 +118,13 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          lein with-profile +test cloverage --codecov
+          lein kaocha --plugin cloverage --codecov --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
       - store_artifacts:
           path: ./logs
       - store_artifacts:
           path: target/coverage
       - store_test_results:
-          path: target/test-results
+          path: test-results
       - run:
           name: Report Test Coverage
           command: bash <(curl -s https://codecov.io/bash)
@@ -146,7 +146,7 @@ jobs:
             export REAL_GPG=$(which gpg)
 
             lein do jar, pom, deploy clojars
-    
+
   deploy_snapshot:
     <<: *deploy_config
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          lein kaocha --plugin cloverage --codecov --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+          lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
       - store_artifacts:
           path: ./logs
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+          lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml --plugin cloverage --codecov
       - store_artifacts:
           path: ./logs
       - store_artifacts:

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/core.cache "0.7.2"]]
 
-  :aliases {"kaocha" ["with-profile" "+test" "run" "-m" "kaocha.runner"]}
+  :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.fn-impl jackdaw.serdes.edn]
   :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 
@@ -67,6 +67,7 @@
              {:source-paths
               ["dev"]
 
+              :resource-paths ["test/resources"]
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "0.3.2"]
                              [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
@@ -76,10 +77,6 @@
                              [lambdaisland/kaocha-cloverage "0.0-32"]
                              [lambdaisland/kaocha-junit-xml "0.0-70"]]}
 
-             :test
-             {:resource-paths ["test/resources"]
-              :plugins [[lein-cloverage "1.0.13"]]}
-
              ;; This is not in fact what lein defines repl to be
              :repl
-             [:default :dev :test]})
+             [:default :dev]})

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/core.cache "0.7.2"]]
 
+  :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.fn-impl jackdaw.serdes.edn]
   :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 
@@ -70,7 +71,10 @@
               :dependencies [[io.aviso/logging "0.3.2"]
                              [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
                              [org.apache.kafka/kafka-clients "2.2.0" :classifier "test"]
-                             [org.clojure/test.check "0.9.0"]]}
+                             [org.clojure/test.check "0.9.0"]
+                             [lambdaisland/kaocha "0.0-529"]
+                             [lambdaisland/kaocha-cloverage "0.0-32"]
+                             [lambdaisland/kaocha-junit-xml "0.0-70"]]}
 
              :test
              {:resource-paths ["test/resources"]

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/core.cache "0.7.2"]]
 
-  :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
+  :aliases {"kaocha" ["with-profile" "+test" "run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.fn-impl jackdaw.serdes.edn]
   :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 

--- a/test/jackdaw/admin_test.clj
+++ b/test/jackdaw/admin_test.clj
@@ -143,8 +143,8 @@
     (fn [client]
       (let [{:keys [foo bar]} test-topics]
         (admin/create-topics! client [foo bar])
-        (= {"some-key" "some-value"}
-           (admin/get-broker-config client 0))))))
+        (is (= {"some-key" "some-value"}
+               (admin/get-broker-config client 0)))))))
 
 (deftest test-describe-topics-config
   (with-mock-admin-client test-cluster


### PR DESCRIPTION
- use kaocha to run tests (https://github.com/lambdaisland/kaocha)
- merge the only test profile setting into dev
- remove lein-cloverage
- support the test failure summary in circleci by publishing the test results

A failure will look like this with this change:

<img width="846" alt="Screenshot 2019-08-23 at 15 53 57" src="https://user-images.githubusercontent.com/53640/63602068-940f4e80-c5be-11e9-8f38-5545bdf04f0c.png">
