### PR TITLE
throw an error if a command failed

### DIFF
--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -18,7 +18,7 @@ not write them, and will eventually abandon them)
 The test machine also aims to be agnostic to the system it is testing, other
 than that it should get input/output primarily from Kafka.
 
-### Construction 
+### Construction
 
 The examples below, demonstrate how to create a test machine for executing a
 sequence of "commands". The "local-machine" will execute the commands against a
@@ -51,7 +51,7 @@ to these services in a shared environment like uat/staging.
                            :config local-kafka-config
                            :topics topic-config})]
     (j.t/test-machine {:transport t})))
-    
+
 (def remote-machine []
   (let [t (trns/transport {:type :confluent-rest-proxy
                            :config remote-kafka-config
@@ -79,13 +79,6 @@ listed in the topic-config are read using the corresponding deserializer.
 The test-machine implements the `Closeable` protocol so be sure to use it in
 conjunction with `with-open` to ensure that associated resources are shut down
 cleanly when you are finished with a machine.
-
-```clojure
-(deftest test-my-app
-  (with-open [machine (local-machine))]
-    (let [result (j.t/run-test machine test-commands)]
-      (is (all-ok? result))))
-```
 
 ### Test Commands
 
@@ -150,4 +143,3 @@ requirements.
     (with-open [machine (test-machine {:transport transport})]
       (f machine))))
 ```
-

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -130,10 +130,17 @@
     {:results (loop [results []
                      cmd-list commands]
                 (cond
-                  (first cmd-list) (let [r (exe (first cmd-list))]
-                                     (if (or (contains? (:result r) :error) (empty? (rest cmd-list)))
-                                       (conj results r)
-                                       (recur (conj results r) (rest cmd-list))))
+                  (first cmd-list) (let [cmd (first cmd-list)
+                                         r (exe (first cmd-list))
+                                         res (conj results r)]
+
+                                     (if (contains? (:result r) :error)
+                                       (throw (ex-info (format "Command %s failed" cmd)
+                                                       {:result res}))
+
+                                       (if (empty? (rest cmd-list))
+                                         res
+                                         (recur res (rest cmd-list)))))
                   :else results))
      :journal @(:journal machine)}))
 

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -109,6 +109,23 @@
      (log/info "created test machine")
      m)))
 
+(defn- run-commands
+  "Run commands in the given order, throwing an exception if one fails"
+  [machine commands]
+  (loop [results []
+         [cmd & rest-cmds] commands]
+    (if (nil? cmd)
+      results
+      (let [r ((:executor machine) machine cmd)
+            results' (conj results r)]
+
+        (if (= :error (:status r))
+          (throw (ex-info (format "Command %s failed" cmd)
+                          {:result results'
+                           :command cmd}))
+
+          (recur results' rest-cmds))))))
+
 (defn run-test
   "Runs a sequence of test commands against a test-machine and returns a
    response map.
@@ -124,23 +141,8 @@
    commands to execute. Remember to use `with-open` on the test-machine
    to ensure that all resources are correcly torn down."
   [machine commands]
-  (let [exe (fn [cmd]
-              ((:executor machine) machine cmd))]
-    ;; run commands, stopping if one fails.
-    {:results (loop [results []
-                     [cmd & rest-cmds] commands]
-                (if (nil? cmd)
-                  results
-                  (let [r (exe cmd)
-                        results' (conj results r)]
-
-                    (if (= :error (:status r))
-                      (throw (ex-info (format "Command %s failed" cmd)
-                                      {:result results'
-                                       :command cmd}))
-
-                      (recur results' rest-cmds)))))
-     :journal @(:journal machine)}))
+  {:results (run-commands machine commands)
+   :journal @(:journal machine)})
 
 (defn identity-transport
   "The identity transport simply injects input events directly into

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -128,21 +128,18 @@
               ((:executor machine) machine cmd))]
     ;; run commands, stopping if one fails.
     {:results (loop [results []
-                     cmd-list commands]
-                (cond
-                  (first cmd-list) (let [cmd (first cmd-list)
-                                         r (exe (first cmd-list))
-                                         results' (conj results r)]
+                     [cmd & rest-cmds] commands]
+                (if (nil? cmd)
+                  results
+                  (let [r (exe cmd)
+                        results' (conj results r)]
 
-                                     (if (= :error (:status r))
-                                       (throw (ex-info (format "Command %s failed" cmd)
-                                                       {:result results'
-                                                        :command cmd}))
+                    (if (= :error (:status r))
+                      (throw (ex-info (format "Command %s failed" cmd)
+                                      {:result results'
+                                       :command cmd}))
 
-                                       (if (empty? (rest cmd-list))
-                                         results'
-                                         (recur results' (rest cmd-list)))))
-                  :else results))
+                      (recur results' rest-cmds)))))
      :journal @(:journal machine)}))
 
 (defn identity-transport

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -132,15 +132,16 @@
                 (cond
                   (first cmd-list) (let [cmd (first cmd-list)
                                          r (exe (first cmd-list))
-                                         res (conj results r)]
+                                         results' (conj results r)]
 
-                                     (if (contains? (:result r) :error)
+                                     (if (= :error (:status r))
                                        (throw (ex-info (format "Command %s failed" cmd)
-                                                       {:result res}))
+                                                       {:result results'
+                                                        :command cmd}))
 
                                        (if (empty? (rest cmd-list))
-                                         res
-                                         (recur res (rest cmd-list)))))
+                                         results'
+                                         (recur results' (rest cmd-list)))))
                   :else results))
      :journal @(:journal machine)}))
 

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -147,7 +147,6 @@
 
         (testing "run another test sequence and inspect results"
           (let [{:keys [results journal]} (jd.test/run-test t prog2)]
-            (println "results is = " results)
             (is (every? #(= :ok (:status %)) results))
 
             (testing "old results remain in the journal"

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -77,14 +77,13 @@
           (is (= 3 (count results)))
           (is (every? #(= :ok %) (map :status results)))))
 
-      (testing "execution stops on an error"
-        (let [{:keys [results journal]}
-              (jd.test/run-test m [[:min [1 2 3]]
-                                   [:is-1 2]
-                                   [:max [1 2 3]]])]
-          (is (= 2 (count results)))
-          (is (= :ok (:status (first results))))
-          (is (= :error (:status (second results))))))
+      (testing "execution throws an exception on error"
+        (try
+          (jd.test/run-test m [[:min [1 2 3]]
+                               [:is-1 2]
+                               [:max [1 2 3]]])
+          (catch Exception e
+            (is (= [:is-1 2] (-> e ex-data :command))))))
 
       (testing "execution stops on an unknown command"
         (is (thrown? NullPointerException
@@ -148,6 +147,7 @@
 
         (testing "run another test sequence and inspect results"
           (let [{:keys [results journal]} (jd.test/run-test t prog2)]
+            (println "results is = " results)
             (is (every? #(= :ok (:status %)) results))
 
             (testing "old results remain in the journal"


### PR DESCRIPTION
It's not immediately clear when something went wrong, specially in case of timeouts.

Having it failing noisily and printing out the command that failed would help a lot while writing a new test or debugging an existing test.

This is what it would look like if you have an error in one of the commands with this change (with the results also printed out after that as part of the exception).

<img width="1332" alt="Screenshot 2019-08-28 at 08 58 27" src="https://user-images.githubusercontent.com/53640/63836772-16f32900-c972-11e9-9026-ac52236217ff.png">
