### PR TITLE
New EDN Serde Without the Newline

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
                  [org.clojure/core.cache "0.7.2"]]
 
   :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
-  :aot [jackdaw.serdes.fn-impl jackdaw.serdes.edn]
+  :aot [jackdaw.serdes jackdaw.serdes.fn-impl]
   :plugins [[me.arrdem/lein-git-version "2.0.8"]]
 
   :git-version

--- a/src/jackdaw/serdes.clj
+++ b/src/jackdaw/serdes.clj
@@ -1,8 +1,72 @@
 (ns jackdaw.serdes
-  "Implements basic SerDes (Serializer/Deserializer)."
+  "Implements string and EDN serdes (serializer/deserializer)."
   (:gen-class)
-  (:import [org.apache.kafka.common.serialization Serdes]))
+  (:require [clojure.edn]
+            [jackdaw.serdes.fn :as jsfn])
+  (:import java.nio.charset.StandardCharsets
+           org.apache.kafka.common.serialization.Serde
+           org.apache.kafka.common.serialization.Serdes))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defn to-bytes
+  "Converts a string to a byte array."
+  [data]
+  (.getBytes ^String data StandardCharsets/UTF_8))
+
+(defn- from-bytes
+  "Converts a byte array to a string."
+  [^bytes data]
+  (String. data StandardCharsets/UTF_8))
+
 
 (defn string-serde
   []
   (Serdes/String))
+
+
+(defn edn-serializer
+  "Returns an EDN serializer."
+  []
+  (jsfn/new-serializer {:serialize (fn [_ _ data]
+                                     (when data
+                                       (to-bytes
+                                        (binding [*print-length* false
+                                                  *print-level* false]
+                                          (pr-str data)))))}))
+
+(defn edn-deserializer
+  "Returns an EDN deserializer."
+  ([]
+   (edn-deserializer {}))
+  ([opts]
+   (let [opts (into {} opts)]
+     (jsfn/new-deserializer {:deserialize (fn [_ _ data]
+                                            (->> (from-bytes data)
+                                                 (clojure.edn/read-string opts)))}))))
+
+(defn edn-serde
+  "Implements an EDN SerDes (Serializer/Deserializer).
+
+  The behavior of this serde differs from the one in
+  jackdaw.serdes.edn. It does not print a newline."
+  [& [opts]]
+  (Serdes/serdeFrom (edn-serializer) (edn-deserializer opts)))
+
+(gen-class
+    :name "jackdaw.serdes.EdnSerde"
+	:implements [org.apache.kafka.common.serialization.Serde]
+	:prefix "EdnSerde-")
+
+(def EdnSerde-configure
+  (constantly nil))
+
+(defn EdnSerde-serializer
+  [& _]
+  (edn-serializer))
+
+(defn EdnSerde-deserializer
+  [& _]
+  (edn-deserializer))

--- a/src/jackdaw/serdes/edn.clj
+++ b/src/jackdaw/serdes/edn.clj
@@ -1,15 +1,18 @@
 (ns jackdaw.serdes.edn
-  "Implements an EDN SerDes (Serializer/Deserializer)."
+  "DEPRECATION NOTICE:
+
+  This namespace is deprecated. Please use jackdaw.serdes/edn-serde.
+
+  The behavior of the new EDN serde is different. It does not print
+  the newline.
+
+  Implements an EDN SerDes (Serializer/Deserializer)."
   {:license "BSD 3-Clause License <https://github.com/FundingCircle/jackdaw/blob/master/LICENSE>"}
   (:require [clojure.edn]
             [jackdaw.serdes.fn :as jsfn])
   (:import java.nio.charset.StandardCharsets
            org.apache.kafka.common.serialization.Serde
-           org.apache.kafka.common.serialization.Serdes)
-  (:gen-class
-   :implements [org.apache.kafka.common.serialization.Serde]
-   :prefix "EdnSerde-"
-   :name jackdaw.serdes.EdnSerde))
+           org.apache.kafka.common.serialization.Serdes))
 
 (set! *warn-on-reflection* true)
 
@@ -47,14 +50,3 @@
   "Returns an EDN serde."
   [& [opts]]
   (Serdes/serdeFrom (serializer) (deserializer opts)))
-
-(def EdnSerde-configure
-  (constantly nil))
-
-(defn EdnSerde-serializer
-  [& _]
-  (serializer))
-
-(defn EdnSerde-deserializer
-  [& _]
-  (deserializer))

--- a/test/jackdaw/serdes_test.clj
+++ b/test/jackdaw/serdes_test.clj
@@ -1,0 +1,40 @@
+(ns jackdaw.serdes-test
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer :all]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [jackdaw.serdes :as js]))
+
+(defspec edn-roundtrip-test 20
+  (testing "EDN data is the same after serialization and deserialization."
+    (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]
+      (is (= x (->> (.serialize (js/edn-serializer) nil x)
+                    (.deserialize (js/edn-deserializer) nil)))))))
+
+(defspec edn-reverse-roundtrip-test 20
+  (testing "EDN data is the same after deserialization and serialization."
+    (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]
+      (let [bytes (.serialize (js/edn-serializer) nil x)]
+        (is (= (seq bytes)
+               (seq (->> (.deserialize (js/edn-deserializer) nil bytes)
+                         (.serialize (js/edn-serializer) nil)))))))))
+
+(defspec edn-print-length-test 20
+  (testing "EDN data is the same after serialization and deserialization with *print-length*."
+    (binding [*print-length* 100]
+      (prop/for-all [x (gen/vector gen/int (inc *print-length*))]
+        (is (= x (->> (.serialize (js/edn-serializer) nil x)
+                      (.deserialize (js/edn-deserializer) nil))))))))
+
+(defmethod print-method java.net.URI
+  [obj writer]
+  (.write writer "#jackdaw/uri ")
+  (.write writer (pr-str (str obj))))
+
+(defspec edn-roundtrip-custom-reader 20
+  (testing "custom EDN reader"
+    (let [opts {:readers {'jackdaw/uri #(java.net.URI. %)}}]
+      (prop/for-all [x (s/gen uri?)]
+        (is (= x (->> (.serialize (js/edn-serializer) nil x)
+                      (.deserialize (js/edn-deserializer opts) nil))))))))


### PR DESCRIPTION
This PR adds a new EDN Serde to a separate location (jackdaw.serdes). In the future, we will be able to require all serdes from here.

This serde fixes a longstanding bug in the EDN serde. It does not print a newline. This is important when writing keys since the presence of a newline causes the record to hash to a different partition when using the default partitioner.

This PR also changes the generated class `jackdaw.serdes.EdnSerde` which now points to the new serde. For applications that define this to be the default key serde, this is a BREAKING CHANGE.