### PR TITLE
Skip deploy_snapshots job for external contributors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
       - run:
           name: Deploy to Clojars
           command: |
-            lein do jar, pom, deploy clojars
+            [ -z "$CLOJARS_USERNAME" ] || lein do jar, pom, deploy clojars
 
 workflows:
   version: 2


### PR DESCRIPTION
Currently, external contributors can never merge their PRs because the circleci `deploy_snapshots` job will always fail. This is because it relies on the `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` env vars, which are not injected for PRs from forks (the "Pass secrets to builds from forked pull requests" option is disabled). 

In circleci, it's not possible to conditionally run a step based on an env var, so this PR just updates the `deploy_snapshot` job to do nothing if `CLOJARS_USERNAME` isn't set.