### PR TITLE
Fix word-count-test bugs

### DIFF
--- a/examples/word-count/test/word_count_test.clj
+++ b/examples/word-count/test/word_count_test.clj
@@ -30,7 +30,7 @@
   [word]
   [:watch (fn [journal]
             (some #(= word (:key %))
-                  (get-in journal [:topics :output]))) 2000])
+                  (get-in journal [:topics :output]))) {:timeout 2000}])
 
 (defn word-count
   "A simple helper to extract the latest value from the word-count ktable
@@ -89,7 +89,7 @@
                                topics))
 
     :else
-    (jd.test/mock-transport (mock-transport-config) topic-metadata)))
+    (jd.test/mock-transport (mock-transport-config) topics)))
 
 (deftest test-word-count-example
   (fix/with-fixtures [(fix/integration-fixture wc/topology-builder test-config)]


### PR DESCRIPTION
- Timeout was specified incorrectly. This should be a map.
- test-transport contained a reference to a global var when a local version was available.