### PR TITLE
Only numbers should be num-coercable

### DIFF
--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -190,8 +190,8 @@
   (such as `long`)."
   [x coercion-fn]
   (try
-    (coercion-fn (bigint x))
-    true
+    (and (number? x)
+         (coercion-fn (bigint x)))
     (catch RuntimeException e
       false)))
 

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -266,11 +266,15 @@
           clj-data-long 123
           avro-data-long 123
           clj-data-string "hello"
-          avro-data-string (Utf8. "hello")]
+          avro-data-string (Utf8. "hello")
+          clj-data-num-as-string "123"
+          avro-data-num-as-string (Utf8. "123")]
       (is (= clj-data-long (avro/avro->clj schema-type avro-data-long)))
       (is (= avro-data-long (avro/clj->avro schema-type clj-data-long [])))
       (is (= clj-data-string (avro/avro->clj schema-type avro-data-string)))
-      (is (= (str avro-data-string) (avro/clj->avro schema-type clj-data-string [])))))
+      (is (= (str avro-data-string) (avro/clj->avro schema-type clj-data-string [])))
+      (is (= clj-data-num-as-string (avro/avro->clj schema-type avro-data-num-as-string)))
+      (is (= (str avro-data-num-as-string) (avro/clj->avro schema-type clj-data-num-as-string [])))))
   (testing "marshalling unrecognized union type throws exception"
     (let [avro-schema (parse-schema ["null" "long"])
           schema-type (schema-type avro-schema)]


### PR DESCRIPTION
If you have a union type like `["long" "string"]`, the avro serde would fail to serialise a string which contains a numerical value, eg: `"123"`. I added a test case for that. The fix simply checks if the passed value to the `num-coercable?` function is actually a number.