### PR TITLE
Only set started? to true after equality test for the RUNNING state

### DIFF
--- a/src/jackdaw/test/fixtures.clj
+++ b/src/jackdaw/test/fixtures.clj
@@ -12,7 +12,7 @@
    [clojure.test :as t])
   (:import
    (org.apache.kafka.clients.admin AdminClient NewTopic)
-   (org.apache.kafka.streams KafkaStreams$StateListener)
+   (org.apache.kafka.streams KafkaStreams$StateListener KafkaStreams$State)
    (kafka.tools StreamsResetter)))
 
 ;;; topic-fixture ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -105,7 +105,7 @@
                  (.name old-state)
                  (.name new-state))
       (when-not (realized? started?)
-        (when (.isRunning new-state)
+        (when (= KafkaStreams$State/RUNNING new-state)
           (deliver started? true))))))
 
 (defn- set-error


### PR DESCRIPTION
I would have thought the new version is equivalent to the old here but apparently these are different. It seems to be possible with the old version for the test function to be invoked *before* the application has truly reached the "RUNNING" state. If this results in an application under test failing to read test data submitted during the test (because it was thought to have arrived before the test actually began).

However from reading the logs of test failures, the following sequence of log events is a pretty good predictor of failure for certain tests.

process foo changed state from CREATED -> REBALANCING
commencing test function

I don't really understand how I could see that sequence of log entries without `(.isRunning new-state)` returning `true` when it was just reported as a "REBALANCING" state.

With this change in place, re-running tests that would produce the failure sequence above, instead I see

process foo changed state from CREATED -> REBALANCING
process foo changed state from REBALANCING -> RUNNING
commencing test function

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
