### PR TITLE
Allow Avro records to be configured to be closed/open

### DIFF
--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -340,6 +340,18 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Field garbage not known in Foo"
                             (avro/clj->avro schema-type {:garbage "yolo"} [])))))
+
+  (testing "marshalling open record with unknown field does not trigger error"
+    (let [avro-schema (parse-schema {:type "record"
+                                     :name "Foo"
+                                     :fields [{:name "foo" :type "string"}]})
+          schema-type ((avro/make-coercion-stack
+                        (merge +registry+ avro/+open-record-type-registry+))
+                       avro-schema)
+          avro-data (->generic-record avro-schema {"foo" "bar"})
+          clj-data {:foo "bar" :garbage "yolo"}]
+      (is (= avro-data (avro/clj->avro schema-type clj-data [])))))
+
   (testing "uuid"
     (let [avro-schema (parse-schema {:type "string",
                                      :logicalType "uuid"})


### PR DESCRIPTION
The [Avro specification](https://avro.apache.org/docs/1.8.2/spec.html#Schema+Resolution) states: "if the writer's record contains a field with a name not present in the reader's record, the writer's value for that field is ignored." However, the Avro serde will throw an exception in this case. This PR addresses this by allowing the Avro Record type to be configured to be open or closed (closed is default behaviour).

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
