### PR TITLE
return the error more clearly when something fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
  * Fressian Serde via clojure.data.fressian
+ * More clear error from the command runner #214
 
 ## [0.6.9] - [2019-10-16]
 

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -120,9 +120,11 @@
             results' (conj results r)]
 
         (if (= :error (:status r))
-          (throw (ex-info (format "Command %s failed" cmd)
-                          {:result results'
-                           :command cmd}))
+          (let [error (-> r :result :error)]
+            (throw (ex-info (format "Command %s failed with error %s" cmd error)
+                            {:result results'
+                             :error error
+                             :command cmd})))
 
           (recur results' rest-cmds))))))
 

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -83,7 +83,8 @@
                                [:is-1 2]
                                [:max [1 2 3]]])
           (catch Exception e
-            (is (= [:is-1 2] (-> e ex-data :command))))))
+            (is (= [:is-1 2] (-> e ex-data :command)))
+            (is (= :not-1 (-> e ex-data :error))))))
 
       (testing "execution stops on an unknown command"
         (is (thrown? NullPointerException


### PR DESCRIPTION
The actual error returned by jackdaw when something fails is buried in a massive map, with this change it can be printed out directly as the error message and returned as data as well.