### PR TITLE
Add journal access functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
  * Upgraded in #217:
    * Kafka client version to 2.3.1: https://kafka.apache.org/23/documentation.html#upgrade_230_notable
    * Confluent Platform components version to 5.3.1: https://docs.confluent.io/5.3.1/release-notes/index.html#cp-5-3-1-release-notes
- * Added functions to simply querying the test machine journal (#215)
+ * Added functions to simplify querying the test machine journal (#215)
 
 ## [0.6.9] - [2019-10-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  * Upgraded in #217:
    * Kafka client version to 2.3.1: https://kafka.apache.org/23/documentation.html#upgrade_230_notable
    * Confluent Platform components version to 5.3.1: https://docs.confluent.io/5.3.1/release-notes/index.html#cp-5-3-1-release-notes
+ * Added functions to simply querying the test machine journal (#215)
 
 ## [0.6.9] - [2019-10-16]
 

--- a/test/jackdaw/test/journal_test.clj
+++ b/test/jackdaw/test/journal_test.clj
@@ -1,0 +1,27 @@
+(ns jackdaw.test.journal-test
+  (:require
+    [clojure.test :refer :all]
+    [jackdaw.test.journal :as jrnl]))
+
+(deftest journal-access-tests
+  (let [j {:topics {"foo" [{:key 1
+                            :value {:id 1 :v 99}}
+                           {:key 2
+                            :value {:id 2 :v 88}}
+                           {:key 3
+                            :value {:id 3 :v 77}}]}}]
+
+    (testing "by-key"
+      (is (= {:id 1 :v 99} ((jrnl/by-key "foo" [:id] 1) j)))
+      (is (= {:id 2 :v 88} ((jrnl/by-key "foo" [:v] 88) j))))
+
+    (testing "by-keys"
+      (is (= [{:id 1 :v 99} {:id 2 :v 88}]
+             ((jrnl/by-keys "foo" [:id] [1 2]) j))))
+
+    (testing "by-id"
+      (is (= {:id 2 :v 88} ((jrnl/by-id "foo" 2) j))))
+
+    (testing "all-keys-present"
+      (is ((jrnl/all-keys-present "foo" [:id] [1 2]) j))
+      (is (false? ((jrnl/all-keys-present "foo" [:id] [1 2 4]) j))))))


### PR DESCRIPTION
Adds functions to simply querying the test-machine journal. These can help make the test machine steps a little more concise:

```clj
(with-open [test-machine (j/test-machine ...)]
  (j/run-test test-machine [[:write! :input-topic record]
                            ...
                            [:watch (j/by-key :output-topic-1 [:status] "success")]]
                            [:watch (j/by-id :investor-updated (:id investor))
                            ...])]
```

# Checklist

- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)