### PR TITLE
Use specific context for deploying to Clojars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ workflows:
           requires:
             - deps
       - deploy_snapshot:
+          context: clojars-deploy
           requires:
             - test
           filters:
@@ -186,6 +187,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy:
+          context: clojars-deploy
           requires:
             - checkout_tags
           filters:


### PR DESCRIPTION
💁 Take advantage of a shared context for credentials for deploying to Clojars instead of storing them inline per project.