### PR TITLE
Open up the coercion stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### Added
+
+ * as-edn/as-json functions to convert between representations of avro
+
+### Fixed
+
  * Fixed bug in `map->ProducerRecord`
  * Allow nullable `partition` and `timestamp` in `->ProducerRecord` (previously threw NPE)
 

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -557,18 +557,21 @@
                                   :type-registry (merge avro/+base-schema-type-registry+
                                                         avro/+UUID-type-registry+)}
                                  valid-edn)
-                   (json/read-str))]
-      (is (= "a_1" (get json "enum_field")))
-      (is (= nil (get json "nil_field")))
-      (is (= {"map" {"banana" {"color" "yellow"}, "ripe b4nana$" {"color" "yellow-green"}}}
-             (get json "map_field")))
-      (is (= 1 (get json "default_field")))
-      (is (= "00000000-0000-0000-0000-000000000000" (get json "uuid_field")))
-      (is (= {"array" [{"color" "yellow"}]}
-             (get json "array_field")))
-      (is (= "hello" (get json "string_field")))
-      (is (= nil (get json "optional_field")))
-      (is (= 3 (get json "long_field"))))))
+                   (json/read-str :key-fn keyword))]
+      (is (= "a_1" (:enum_field json)))
+      (is (= nil (:nil_field json)))
+      (is (= {:map {:banana {:color "yellow"},
+                    (keyword "ripe b4nana$") {:color "yellow-green"}}}
+             (:map_field json)))
+      (is (= 1 (:default_field json)))
+      (is (= "00000000-0000-0000-0000-000000000000" (:uuid_field json)))
+      (is (= {:array [{:color "yellow"}]}
+             (:array_field json)))
+      (is (= "hello" (:string_field json)))
+      (is (= nil (:optional_field json)))
+      (is (= 3 (:long_field json))))))
+
+
 
 (deftest schemaless-test
   (let [serde (->serde nil)]


### PR DESCRIPTION
A few people have noticed that the **JSON** representation of an avro object is a bit different to the edn representation of an avro object. This behaviour was originally copied from the [abracad.avro project](https://github.com/damballa/abracad) but it makes it a little bit inconvenient to work with data obtained via more "avro-oriented" tools like the [kafka-avro-console-consumer](https://github.com/confluentinc/schema-registry/blob/master/bin/kafka-avro-console-consumer) or the [avro-random-generator](https://github.com/confluentinc/avro-random-generator).

The pair of functions in this PR make it a bit easier to convert between these two representations.

## Example Usage

### as-json
```
(as-json {:avro-schema (clojure.data.json/write-str ["null" "string"])}
          "yolo")
=> "{\"string\":\"yolo\"}"
```

### as-edn
```
(as-edn {:avro-schema (clojure.data.json/write-str ["null" "string"])}
        "{\"string\":\"yolo\"}")
=> "yolo"
```

## Checklist

- [x] factor out the common code that builds the coercion-stack
- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
