### PR TITLE
[WB-66] Fix avro union serialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
  * Fixed bug in `map->ProducerRecord`
  * Allow nullable `partition` and `timestamp` in `->ProducerRecord` (previously threw NPE)
+ * Fixed union type serialisation when members have similar fields
 
 ## [0.7.0] - [2019-12-19]
 

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -316,9 +316,11 @@
 (defrecord EnumType [^Schema schema]
   SchemaCoercion
   (match-clj? [_ x]
-    (or
-     (string? x)
-     (keyword? x)))
+    (and (or
+          (string? x)
+          (keyword? x))
+         (contains? (set (.getEnumSymbols schema))
+                    (mangle (name x)))))
 
   (match-avro? [_ x]
     (instance? GenericData$EnumSymbol x))
@@ -472,7 +474,7 @@
       (avro->clj schema-type avro-data)))
 
   (clj->avro [_ clj-data path]
-    (if-let [schema-type (match-union-type coercion-types  #(match-clj? % clj-data))]
+    (if-let [schema-type (match-union-type coercion-types #(match-clj? % clj-data))]
       (clj->avro schema-type clj-data path)
       (throw (ex-info (serialization-error-msg clj-data
                                                (->> schemas

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -324,7 +324,8 @@
                     (mangle (name x)))))
 
   (match-avro? [_ x]
-    (instance? GenericData$EnumSymbol x))
+    (and (instance? GenericData$EnumSymbol x)
+         (.hasEnumSymbol schema x)))
 
   (avro->clj [_ avro-enum]
     (-> (str avro-enum)

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -60,6 +60,7 @@
   "
   (:require [clojure.tools.logging :as log]
             [clojure.core.cache :as cache]
+            [clojure.data]
             [clojure.string :as str]
             [jackdaw.serdes.avro.schema-registry :as registry]
             [jackdaw.serdes.fn :as fn])

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -306,10 +306,16 @@
       (is (= (str avro-data-num-as-string) (avro/clj->avro schema-type clj-data-num-as-string [])))
       (is (= (->generic-record (parse-schema record-1-schema) {"a" "x"})
              (avro/clj->avro schema-type {:a :x} [])))
+      (is (= {:a :x}
+             (avro/avro->clj schema-type (->generic-record (parse-schema record-1-schema) {"a" "x"}))))
       (is (= (->generic-record (parse-schema record-2-schema) {"a" "y" "b" "test"})
              (avro/clj->avro schema-type {:a :y :b "test"} [])))
+      (is (= {:a :y :b "test"}
+             (avro/avro->clj schema-type (->generic-record (parse-schema record-2-schema) {"a" "y" "b" "test"}))))
       (is (= (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"})
-             (avro/clj->avro schema-type {:a :y :c "test"} [])))))
+             (avro/clj->avro schema-type {:a :y :c "test"} [])))
+      (is (= {:a :y :c "test"}
+             (avro/avro->clj schema-type (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"}))))))
   (testing "marshalling unrecognized union type throws exception"
     (let [avro-schema (parse-schema ["null" "long"])
           schema-type (schema-type avro-schema)]

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -315,7 +315,10 @@
       (is (= (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"})
              (avro/clj->avro schema-type {:a :y :c "test"} [])))
       (is (= {:a :y :c "test"}
-             (avro/avro->clj schema-type (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"}))))))
+             (avro/avro->clj schema-type (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"}))))
+      (is (thrown? Exception (avro/clj->avro schema-type {:a :y} [])))
+      (is (thrown? Exception (avro/clj->avro schema-type {:a :x :d "test"} [])))
+      (is (thrown? Exception (avro/clj->avro schema-type {:a :x :b "test"} [])))))
   (testing "marshalling unrecognized union type throws exception"
     (let [avro-schema (parse-schema ["null" "long"])
           schema-type (schema-type avro-schema)]

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -277,10 +277,20 @@
                                             :symbols ["y"]}}
                                     {:name "b"
                                      :type ["string" "null"]}]}
+          record-3-schema {:name "recordThree"
+                           :type "record"
+                           :namespace "com.fundingcircle"
+                           :fields [{:name "a"
+                                     :type {:name "enumThree"
+                                            :type "enum"
+                                            :symbols ["y"]}}
+                                    {:name "c"
+                                     :type ["string" "null"]}]}
           avro-schema (parse-schema ["long"
                                      "string"
                                      record-1-schema
-                                     record-2-schema])
+                                     record-2-schema
+                                     record-3-schema])
           schema-type (schema-type avro-schema)
           clj-data-long 123
           avro-data-long 123
@@ -297,7 +307,9 @@
       (is (= (->generic-record (parse-schema record-1-schema) {"a" "x"})
              (avro/clj->avro schema-type {:a :x} [])))
       (is (= (->generic-record (parse-schema record-2-schema) {"a" "y" "b" "test"})
-             (avro/clj->avro schema-type {:a :y :b "test"} [])))))
+             (avro/clj->avro schema-type {:a :y :b "test"} [])))
+      (is (= (->generic-record (parse-schema record-3-schema) {"a" "y" "c" "test"})
+             (avro/clj->avro schema-type {:a :y :c "test"} [])))))
   (testing "marshalling unrecognized union type throws exception"
     (let [avro-schema (parse-schema ["null" "long"])
           schema-type (schema-type avro-schema)]


### PR DESCRIPTION
When serialising a clojure map to an avro record with a union type schema, the avro serialisation will pick the wrong union type member, and then the serialisation will fail (I'll post a message in slack with more detail). I think the root cause of this is that the `match-clj?` method isn't strict enough for enums and records. I've therefore made this more strict, which fixes the union type serialisation.

# Checklist

- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
