### PR TITLE
Formalizing the test-machine command API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /jackdaw-[a-z]*/checkouts
 /jackdaw-[a-z]*/target
 /target
+/test-results
 /logs
 pom.xml
 pom.xml.asc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## Fixed
+## Unreleased
+
+### Added
+
+* Start formalizing test-machine commands with fspec'd functions
+
+## [0.7.2] - [2020-02-07]
+
+### Fixed
 
 * Fixed bug in Avro deserialisation, when handling a union of enum types
 

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -44,7 +44,7 @@
 
 (s/def ::topic-id (s/or ::keyword keyword?
                         ::string string?))
-(s/def ::test-msg any?)
+(s/def ::test-message any?)
 (s/def ::write-options map?)
 (s/def ::watch-options map?)
 
@@ -71,17 +71,17 @@
 
 (s/fdef write!
   :args (s/cat :topic-id ::topic-id
-               :msg ::test-msg
-               :opts (s/? ::write-options))
+               :message ::test-msg
+               :options (s/? ::write-options))
   :ret vector?)
 
 (defn watch
   ([watch-query]
    `[:watch ~watch-query])
-  ([watch-query opts]
-   `[:watch ~watch-query ~opts]))
+  ([watch-query options]
+   `[:watch ~watch-query ~options]))
 
 (s/fdef watch
-  :args (s/cat :watch ifn?
-               :opts (s/? ::watch-options))
+  :args (s/cat :watch-query ifn?
+               :options (s/? ::watch-options))
   :ret vector?)

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -71,7 +71,7 @@
 
 (s/fdef write!
   :args (s/cat :topic-id ::topic-id
-               :message ::test-msg
+               :message ::test-message
                :options (s/? ::write-options))
   :ret vector?)
 

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -42,20 +42,30 @@
 
 ;; Test Command API
 
-(s/def ::topic-id (s/or ::keyword keyword?
-                        ::string string?))
+(s/def ::topic-id (s/or :keyword keyword?
+                        :string string?))
 (s/def ::test-message any?)
 (s/def ::write-options map?)
 (s/def ::watch-options map?)
 
-(defn do [do-fn]
+(defn do
+  "Invoke the provided function, passing a snapshot of the test journal
+
+   Use this to perform side-effects without representing their result in the journal"
+  [do-fn]
   `[:do ~do-fn])
 
 (s/fdef do
   :args ifn?
   :ret vector?)
 
-(defn do! [do-fn]
+(defn do!
+  "Invoke the provided function, passing the journal `ref`
+
+   Use this to perform side-effects when you want to represent the result in the journal
+   (e.g. insert test-data into an external database AND into the journal with the expectation
+   that it will eventually appear in kafka via some external system like kafka-connect)"
+  [do-fn]
   `[:do! ~do-fn])
 
 (s/fdef do!
@@ -63,6 +73,17 @@
   :ret vector?)
 
 (defn write!
+  "Write a message to the topic identified in the topic-metadata by `topic-id`
+
+   `:message` is typically a map to be serialized by the Serde configured in the topic-metadata
+              but it can be whatever the configued Serde is capable of serializing
+   `:options` is an optional map containing additional information describing how the test-message
+              should be created. The following properties are supported.
+
+      `:key`             An explicit key to associate with the test message
+      `:key-fn`          A function to derive the key from the test message
+      `:partition`       The partition to which the test message should be written
+      `:partition-fn`    A function to derive the partition to which the test message should be written"
   ([topic-id message]
    `[:write! ~topic-id ~message])
 
@@ -76,12 +97,22 @@
   :ret vector?)
 
 (defn watch
-  ([watch-query]
-   `[:watch ~watch-query])
-  ([watch-query options]
-   `[:watch ~watch-query ~options]))
+  "Watch the test-journal until the `watch-fn` predicate returns true
+
+   `:watch-fn` is a function that takes the journal and returns true once the journal
+               contains evidence of the test being complete
+   `:options` is an optional map containing additional information describing how the watch
+              function will be run. The following properties are supported.
+
+      `:info` Diagnostic information to be included in the response when a watch fails
+              to observe the expected data in the journal
+      `:timeout` The number of milliseconds to wait before giving up"
+  ([watch-fn]
+   `[:watch ~watch-fn])
+  ([watch-fn options]
+   `[:watch ~watch-fn ~options]))
 
 (s/fdef watch
-  :args (s/cat :watch-query ifn?
+  :args (s/cat :watch-fn ifn?
                :options (s/? ::watch-options))
   :ret vector?)

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -3,7 +3,8 @@
   (:require
    [jackdaw.test.commands.base :as base]
    [jackdaw.test.commands.write :as write]
-   [jackdaw.test.commands.watch :as watch]))
+   [jackdaw.test.commands.watch :as watch])
+  (:refer-clojure :exclude [do]))
 
 (def base-commands base/command-map)
 (def write-command write/command-map)
@@ -37,3 +38,22 @@
   [machine handler]
   (assoc machine
          :command-handler handler))
+
+(defn do [do-fn]
+  `[:do ~do-fn])
+
+(defn do! [do-fn]
+  `[:do! ~do-fn])
+
+(defn write!
+  ([topic-id message]
+   `[:write! ~topic-id ~message])
+
+  ([topic-id message options]
+   `[:write! ~topic-id ~message ~options]))
+
+(defn watch
+  ([watch-query]
+   `[:watch ~watch-query])
+  ([watch-query opts]
+   `[:watch ~watch-query ~opts]))

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -42,7 +42,8 @@
 
 ;; Test Command API
 
-(s/def ::topic-id keyword?)
+(s/def ::topic-id (s/or ::keyword keyword?
+                        ::string string?))
 (s/def ::test-msg any?)
 (s/def ::write-options map?)
 (s/def ::watch-options map?)
@@ -69,7 +70,9 @@
    `[:write! ~topic-id ~message ~options]))
 
 (s/fdef write!
-  :args (s/cat ::topic-id ::write-options)
+  :args (s/cat :topic-id ::topic-id
+               :msg ::test-msg
+               :opts (s/? ::write-options))
   :ret vector?)
 
 (defn watch
@@ -79,6 +82,6 @@
    `[:watch ~watch-query ~opts]))
 
 (s/fdef watch
-  :args (s/cat ::watch-query ifn?
-               ::opts ::watch-options)
+  :args (s/cat :watch ifn?
+               :opts (s/? ::watch-options))
   :ret vector?)

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -1,6 +1,7 @@
 (ns jackdaw.test.commands
   ""
   (:require
+   [clojure.spec.alpha :as s]
    [jackdaw.test.commands.base :as base]
    [jackdaw.test.commands.write :as write]
    [jackdaw.test.commands.watch :as watch])
@@ -39,11 +40,26 @@
   (assoc machine
          :command-handler handler))
 
+;; Test Command API
+
+(s/def ::topic-id keyword?)
+(s/def ::test-msg any?)
+(s/def ::write-options map?)
+(s/def ::watch-options map?)
+
 (defn do [do-fn]
   `[:do ~do-fn])
 
+(s/fdef do
+  :args ifn?
+  :ret vector?)
+
 (defn do! [do-fn]
   `[:do! ~do-fn])
+
+(s/fdef do!
+  :args ifn?
+  :ret vector?)
 
 (defn write!
   ([topic-id message]
@@ -52,8 +68,17 @@
   ([topic-id message options]
    `[:write! ~topic-id ~message ~options]))
 
+(s/fdef write!
+  :args (s/cat ::topic-id ::write-options)
+  :ret vector?)
+
 (defn watch
   ([watch-query]
    `[:watch ~watch-query])
   ([watch-query opts]
    `[:watch ~watch-query ~opts]))
+
+(s/fdef watch
+  :args (s/cat ::watch-query ifn?
+               ::opts ::watch-options)
+  :ret vector?)

--- a/src/jackdaw/test/commands/base.clj
+++ b/src/jackdaw/test/commands/base.clj
@@ -1,6 +1,6 @@
 (ns jackdaw.test.commands.base
   (:require
-    [clojure.pprint :as pprint]))
+   [clojure.pprint :as pprint]))
 
 (def command-map
   {:stop (constantly true)


### PR DESCRIPTION
### Rationale

The test-machine commands are "just data". This allows them to be created using whatever method is convenient (e.g. generated from the contents of some edn file, extracted from a database, read from an existing kafka topic etc.). However when authoring commands from scratch, it can be annoying to have to remember the syntax of each command (or keep referring back to the docs).

This PR adds some functions in the jackdaw.test.commands ns to provide a bit of help for this use-case. Having (spec'd) functions means that tools like cider can give us a bit of interactive help without the need to leave our editor. The specs are very basic for now but we can further refine them (particularly the `::write-options` and `::watch-options` specs) to provide even better assistance. As an example, the screenshot below is the result from `M-x cider-doc` on the `jackdaw.test.commands/watch` function.

<img width="663" alt="Screen Shot 2020-02-12 at 5 01 17 PM" src="https://user-images.githubusercontent.com/48030/74358481-66f76800-4db9-11ea-98fe-74784654a413.png">

### Checklist

- [x] tests (updated existing tests)
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
