### PR TITLE
Add name support for windowed joins

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -144,7 +144,9 @@
   ([kstream other-kstream value-joiner-fn windows]
    (p/join-windowed kstream other-kstream value-joiner-fn windows))
   ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
-   (p/join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config)))
+   (p/join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config))
+  ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
+   (p/join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name)))
 
 (defn left-join-windowed
   "Combines the values of two streams that share the same key using a
@@ -152,7 +154,9 @@
   ([kstream other-kstream value-joiner-fn windows]
    (p/left-join-windowed kstream other-kstream value-joiner-fn windows))
   ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
-   (p/left-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config)))
+   (p/left-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config))
+  ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
+   (p/left-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name)))
 
 (defn map
   "Creates a KStream that consists of the result of applying
@@ -166,7 +170,9 @@
   ([kstream other-kstream value-joiner-fn windows]
    (p/outer-join-windowed kstream other-kstream value-joiner-fn windows))
   ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
-   (p/outer-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config)))
+   (p/outer-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config))
+  ([kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
+   (p/outer-join-windowed kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name)))
 
 (defn process!
   "Applies `processor-fn` to each item in the input stream."

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -188,6 +188,18 @@
                     topic-config
                     other-topic-config)))
 
+  (join-windowed
+    [_ other-kstream value-joiner-fn windows topic-config other-topic-config join-name]
+    (configured-kstream
+     config
+     (join-windowed kstream
+                    other-kstream
+                    value-joiner-fn
+                    windows
+                    topic-config
+                    other-topic-config
+                    join-name)))
+
   (left-join-windowed
     [_ other-kstream value-joiner-fn windows]
     (configured-kstream
@@ -204,6 +216,18 @@
                          windows
                          topic-config
                          other-topic-config)))
+
+  (left-join-windowed
+    [_ other-kstream value-joiner-fn windows topic-config other-topic-config join-name]
+    (configured-kstream
+     config
+     (left-join-windowed kstream
+                         other-kstream
+                         value-joiner-fn
+                         windows
+                         topic-config
+                         other-topic-config
+                         join-name)))
 
   (map
     [_ key-value-mapper-fn]
@@ -237,6 +261,18 @@
                           windows
                           topic-config
                           other-topic-config)))
+
+  (outer-join-windowed
+    [_ other-kstream value-joiner-fn windows topic-config other-topic-config join-name]
+    (configured-kstream
+     config
+     (outer-join-windowed kstream
+                          other-kstream
+                          value-joiner-fn
+                          windows
+                          topic-config
+                          other-topic-config
+                          join-name)))
 
   (process!
     [_ processor-supplier-fn state-store-names]

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -253,6 +253,18 @@
             ^JoinWindows windows
             (Joined/with key-serde this-value-serde other-value-serde))))
 
+  (join-windowed
+    [_ other-kstream value-joiner-fn windows
+     {key-serde :key-serde this-value-serde :value-serde}
+     {other-value-serde :value-serde}
+     join-name]
+    (clj-kstream
+     (.join kstream
+            ^KStream (kstream* other-kstream)
+            ^ValueJoiner (value-joiner value-joiner-fn)
+            ^JoinWindows windows
+            (Joined/with key-serde this-value-serde other-value-serde join-name))))
+
   (left-join-windowed
     [_ other-kstream value-joiner-fn windows]
     (clj-kstream
@@ -271,6 +283,18 @@
                 ^ValueJoiner (value-joiner value-joiner-fn)
                 ^JoinWindows windows
                 (Joined/with key-serde value-serde other-value-serde))))
+
+  (left-join-windowed
+    [_ other-kstream value-joiner-fn windows
+     {:keys [key-serde value-serde]}
+     {other-value-serde :value-serde}
+     join-name]
+    (clj-kstream
+     (.leftJoin kstream
+                ^KStream (kstream* other-kstream)
+                ^ValueJoiner (value-joiner value-joiner-fn)
+                ^JoinWindows windows
+                (Joined/with key-serde value-serde other-value-serde join-name))))
 
   (map
     [_ key-value-mapper-fn]
@@ -301,6 +325,18 @@
                  ^ValueJoiner (value-joiner value-joiner-fn)
                  ^JoinWindows windows
                  (Joined/with key-serde value-serde other-value-serde))))
+
+  (outer-join-windowed
+    [_ other-kstream value-joiner-fn windows
+     {key-serde :key-serde value-serde :value-serde}
+     {other-value-serde :value-serde}
+     join-name]
+    (clj-kstream
+     (.outerJoin ^KStream kstream
+                 ^KStream (kstream* other-kstream)
+                 ^ValueJoiner (value-joiner value-joiner-fn)
+                 ^JoinWindows windows
+                 (Joined/with key-serde value-serde other-value-serde join-name))))
 
   (process!
     [_ processor-supplier-fn state-store-names]

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -115,12 +115,14 @@
   (join-windowed
     [kstream other-kstream value-joiner-fn windows]
     [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
+    [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
     "Combines the values of two streams that share the same key using a
     windowed inner join.")
 
   (left-join-windowed
     [kstream other-kstream value-joiner-fn windows]
     [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
+    [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
     "Combines the values of two streams that share the same key using a
     windowed left join.")
 
@@ -136,6 +138,7 @@
   (outer-join-windowed
     [kstream other-kstream value-joiner-fn windows]
     [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config]
+    [kstream other-kstream value-joiner-fn windows this-topic-config other-topic-config join-name]
     "Combines the values of two streams that share the same key using a
     windowed outer join.")
 

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -178,7 +178,8 @@
                      :value-joiner-fn ifn?
                      :windows join-windows?
                      :this-topic-config (s/? ::topic-config)
-                     :other-topic-config (s/? ::topic-config))
+                     :other-topic-config (s/? ::topic-config)
+                     :join-name (s/? string?))
         :ret kstream?)
 
 (s/fdef k/left-join-windowed
@@ -187,7 +188,8 @@
                      :value-joiner-fn ifn?
                      :windows join-windows?
                      :this-topic-config (s/? ::topic-config)
-                     :other-topic-config (s/? ::topic-config))
+                     :other-topic-config (s/? ::topic-config)
+                     :join-name (s/? string?))
         :ret kstream?)
 
 (s/fdef k/map
@@ -206,7 +208,8 @@
                      :value-joiner-fn ifn?
                      :windows join-windows?
                      :this-topic-config (s/? ::topic-config)
-                     :other-topic-config (s/? ::topic-config))
+                     :other-topic-config (s/? ::topic-config)
+                     :join-name (s/? string?))
         :ret kstream?)
 
 (s/fdef k/process!

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -310,6 +310,7 @@
     (let [topic-a (mock/topic "topic-a")
           topic-b (mock/topic "topic-b")
           topic-c (mock/topic "topic-c")
+          topic-d (mock/topic "topic-d")
           windows (JoinWindows/of 1000)
           driver (mock/build-driver (fn [builder]
                                       (let [left-kstream (k/kstream builder topic-a)
@@ -320,14 +321,23 @@
                                                              windows
                                                              topic-a
                                                              topic-b)
-                                            (k/to topic-c)))))
+                                            (k/to topic-c))
+                                        (-> left-kstream
+                                            (k/join-windowed right-kstream
+                                                             +
+                                                             windows
+                                                             topic-a
+                                                             topic-b
+                                                             "a-b-windowed-join")
+                                            (k/to topic-d)))))
           publish-a (partial mock/publish driver topic-a)
           publish-b (partial mock/publish driver topic-b)]
 
       (publish-a 1 1 1)
       (publish-b 100 1 2)
       (publish-b 10000 1 4) ;; Outside of join window
-      (is (= [[1 3]] (mock/get-keyvals driver topic-c)))))
+      (is (= [[1 3]] (mock/get-keyvals driver topic-c)))
+      (is (= [[1 3]] (mock/get-keyvals driver topic-d)))))
 
   (testing "map"
     (let [topic-a (mock/topic "topic-a")


### PR DESCRIPTION
Re: https://github.com/FundingCircle/jackdaw/issues/178

Added a 7-arity version of `join-windowed`, `left-join-windowed`, and `outer-join-windowed` to allow explicit join names to be specified.

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
