### PR TITLE
Remove dependency on org.apache.kafka/kafka_2.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,6 @@
                  [io.confluent/kafka-avro-serializer "5.3.1"]
                  [org.apache.kafka/kafka-clients "2.3.1"]
                  [org.apache.kafka/kafka-streams "2.3.1"]
-                 [org.apache.kafka/kafka_2.11 "2.3.1"]
                  [org.apache.kafka/kafka-streams-test-utils "2.3.1"]
                  [org.clojure/clojure "1.10.1" :scope "provided"]
                  [org.clojure/data.json "0.2.6"]
@@ -74,6 +73,7 @@
                              [org.apache.kafka/kafka-streams-test-utils "2.3.1"]
                              [org.apache.kafka/kafka-clients "2.3.1" :classifier "test"]
                              [org.clojure/test.check "0.9.0"]
+                             [org.apache.kafka/kafka_2.11 "2.3.1"]
                              [lambdaisland/kaocha "0.0-529"]
                              [lambdaisland/kaocha-cloverage "0.0-32"]
                              [lambdaisland/kaocha-junit-xml "0.0-70"]]}


### PR DESCRIPTION
Tested as follows:

**Without the dependency**
1. commented out the kafka_2.11 dep in the `project.clj`
2. started a REPL
3. loaded the ` jackdaw.test.fixtures` ns
4. Evaled `((reset-application-fixture {"application.id" "foo" "bootstrap.servers" "dummy"}) (fn []))
` at the REPL from that ns, got this expected result: 
```
Execution error at jackdaw.test.fixtures/reset-application-fixture$fn (form-init9876001671492860525.clj:221).
You must add a dependency on a kafka distrib which ships the kafka.tools.StreamsResetter tool
```

**With the dependency**
1. Started a REPL
2. loaded the ` jackdaw.test.fixtures` ns
3. Evaled `((reset-application-fixture {"application.id" "foo" "bootstrap.servers" "dummy"}) (fn []))
` at the REPL from that ns
The StreamResetter tool was invoked but threw an exception due to the dummy params.
