### PR TITLE
standalone deser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Allow avro deserializaton via the resolver without a local copy of the schema
+
 * Start formalizing test-machine commands with fspec'd functions
 
 ## [0.7.2] - [2020-02-07]

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -10,26 +10,26 @@
   The intentional API of this NS has three main features -
   `SchemaCoercion`, the intentional type registry (of which
   `#'+base-schema-type-registry+` is an example) and
-  `#'avro-serde`.
+  `#'serde`.
 
-  `avro-serde` is the primary entry point to this namespace for
-  users. It's a function of a schema-registry configuration, a schema
+  `serde` is the primary entry point to this namespace for users.
+  It's a function of a schema-registry configuration, a schema
   type registry, and a serde configuration to be instantiated.
 
-  The intent is that an end user will `partial` the `avro-serde`
+  The intent is that an end user will `partial` the `serde`
   function with their schema registry details and desired type
   registry, and use the `partial`'d function as en entry in a registry
   as used by `jackdaw.serdes/serde`.
 
-  This allows `serdes` and `avro-serde` to be agnostic to application
-  or environment specific configuration details.
+  This allows `serdes` and `serde` to be agnostic to application or
+  environment specific configuration details.
 
   But what's this type registry?
 
   Apache Avro \"logical types\" - a tool for annotating fields in an
   avro record as having some complex interpretation beyond their
   serialized format. The `type-registry` for the purposes of the
-  `avro-serde` function a mapping of addresses to functions which will
+  `serde` function a mapping of addresses to functions which will
   when invoked build and return a `SchemaCoercion` instance.
 
   When a Serde is instantiated, a stack of `SchemaCoercion` coersion
@@ -50,7 +50,7 @@
   appropriate handler.
 
   A user who wanted to opt into these handlers could simply call
-  `avro-serde` with
+  `serde` with
   `(merge +base-schema-type-registry+ +UUID-type-registry+)`
 
   Users are HIGHLY encouraged to use the `+base-schema-type-registry+`

--- a/src/jackdaw/serdes/avro/confluent.clj
+++ b/src/jackdaw/serdes/avro/confluent.clj
@@ -8,7 +8,8 @@
   serde operation."
   [schema-registry-url schema key? & [{:keys [type-registry
                                               schema-registry-client
-                                              coercion-cache]}]]
+                                              coercion-cache
+                                              read-only?]}]]
   (let [reg (if (nil? type-registry)
               jsa/+base-schema-type-registry+
               type-registry)]
@@ -17,4 +18,5 @@
                 :avro.schema-registry/client schema-registry-client}
                {:avro/schema schema
                 :key? key?
-                :avro/coercion-cache coercion-cache})))
+                :avro/coercion-cache coercion-cache
+                :read-only? read-only?})))

--- a/src/jackdaw/specs.clj
+++ b/src/jackdaw/specs.clj
@@ -20,6 +20,7 @@
 (s/def ::serde-keyword qualified-keyword?)
 (s/def ::schema string?)
 (s/def ::schema-filename string?)
+(s/def ::read-only? boolean?)
 (s/def ::key? boolean?)
 
 (s/def :jackdaw.serde/serde
@@ -31,11 +32,20 @@
 
 ;; Avro serde
 
-(s/def :jackdaw.serde/confluent-avro-serde
-  (s/keys :req-un [::serde-keyword
-                   ::key?
-                   (or ::schema ::schema-filename)]))
+(defn exactly-one-true?
+  [& args]
+  (= 1 (count (filter identity args))))
 
+(s/def :jackdaw.serde/confluent-avro-serde
+  (s/and
+   (s/keys :req-un [::serde-keyword
+                    ::key?
+                    (or ::schema
+                        ::schema-filename
+                        ::read-only?)])
+   #(exactly-one-true? (:schema %)
+                       (:schema-filename %)
+                       (:read-only? %))))
 
 
 ;; Topics as used by creation clients


### PR DESCRIPTION
Updates some stale comments.

Changes the spec for avro serdes so that the schema document is optional. This allows a reader to continue using a topic as the producer evolves their schema, without updating the schemas documents in lockstep.

# Checklist

- [x] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
