### PR TITLE
Add flat-transform wrappers for Kafka Streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,6 @@ jobs:
           lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
       - store_artifacts:
           path: ./logs
-      - store_artifacts:
-          path: target/coverage
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,11 +119,16 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
-          lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+          lein kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml --plugin cloverage --codecov
       - store_artifacts:
           path: ./logs
+      - store_artifacts:
+          path: target/coverage
       - store_test_results:
           path: test-results
+      - run:
+          name: Report Test Coverage
+          command: bash <(curl -s https://codecov.io/bash)
 
   deploy:
     <<: *deploy_config

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -46,6 +46,12 @@
   [streams-builder]
   (p/source-topics streams-builder))
 
+(defn with-state-store
+  "Adds a persistent state store to the topology with the configured name
+  and serdes"
+  [streams-builder store-config]
+  (p/with-state-store streams-builder store-config))
+
 (defn streams-builder*
   "Returns the underlying KStreamBuilder."
   [streams-builder]
@@ -200,6 +206,15 @@
   ([kstream transformer-supplier-fn state-store-names]
    (p/transform kstream transformer-supplier-fn state-store-names)))
 
+(defn flat-transform
+  "Creates a KStream that consists of the results of applying the transformer
+  to each value in the input stream. Result of the transform should be iterable,
+  and the resulting stream is as per flatMap"
+  ([kstream transformer-supplier-fn]
+   (p/flat-transform kstream transformer-supplier-fn))
+  ([kstream transformer-supplier-fn state-store-names]
+   (p/flat-transform kstream transformer-supplier-fn state-store-names)))
+
 (defn transform-values
   "Creates a KStream that consists of the results of applying the transformer
   to each value in the input stream."
@@ -207,6 +222,15 @@
    (p/transform-values kstream value-transformer-supplier-fn))
   ([kstream value-transformer-supplier-fn state-store-names]
    (p/transform-values kstream value-transformer-supplier-fn state-store-names)))
+
+(defn flat-transform-values
+  "Creates a KStream that consists of the results of applying the transformer
+  to each value in the input stream. Result of the transform should be iterable,
+  and the resulting stream is as per flatMap"
+  ([kstream value-transformer-supplier-fn]
+   (p/flat-transform-values kstream value-transformer-supplier-fn))
+  ([kstream value-transformer-supplier-fn state-store-names]
+   (p/flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
 
 (defn join-global
   [kstream global-ktable kv-mapper joiner]

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -198,6 +198,24 @@
   [kstream select-key-value-mapper-fn]
   (p/select-key kstream select-key-value-mapper-fn))
 
+(defn join-global
+  [kstream global-ktable kv-mapper joiner]
+  (p/join-global kstream global-ktable kv-mapper joiner))
+
+(defn left-join-global
+  [kstream global-ktable kv-mapper joiner]
+  (p/left-join-global kstream global-ktable kv-mapper joiner))
+
+(defn merge
+  [kstream other]
+  (p/merge kstream other))
+
+(defn kstream*
+  "Returns the underlying KStream object."
+  [kstream]
+  (p/kstream* kstream))
+
+;; ITransformingKStream
 (defn transform
   "Creates a KStream that consists of the results of applying the transformer
   to each key/value in the input stream."
@@ -231,23 +249,6 @@
    (p/flat-transform-values kstream value-transformer-supplier-fn))
   ([kstream value-transformer-supplier-fn state-store-names]
    (p/flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
-
-(defn join-global
-  [kstream global-ktable kv-mapper joiner]
-  (p/join-global kstream global-ktable kv-mapper joiner))
-
-(defn left-join-global
-  [kstream global-ktable kv-mapper joiner]
-  (p/left-join-global kstream global-ktable kv-mapper joiner))
-
-(defn merge
-  [kstream other]
-  (p/merge kstream other))
-
-(defn kstream*
-  "Returns the underlying KStream object."
-  [kstream]
-  (p/kstream* kstream))
 
 ;; IKTable
 

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -260,6 +260,22 @@
      config
      (select-key kstream key-value-mapper-fn)))
 
+  (left-join-global
+    [_ global-ktable kv-mapper joiner]
+    (configured-kstream
+      config
+      (left-join-global kstream global-ktable kv-mapper joiner)))
+
+  (join-global
+    [_ global-ktable kv-mapper joiner]
+    (configured-kstream
+      config
+      (join-global kstream global-ktable kv-mapper joiner)))
+
+  (kstream* [_]
+    (kstream* kstream))
+
+  ITransformingKStream
   (transform
     [this transformer-supplier-fn]
     (transform this transformer-supplier-fn []))
@@ -299,21 +315,6 @@
     (configured-kstream
      config
      (flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
-
-  (left-join-global
-    [_ global-ktable kv-mapper joiner]
-    (configured-kstream
-      config
-      (left-join-global kstream global-ktable kv-mapper joiner)))
-
-  (join-global
-    [_ global-ktable kv-mapper joiner]
-    (configured-kstream
-      config
-      (join-global kstream global-ktable kv-mapper joiner)))
-
-  (kstream* [_]
-    (kstream* kstream))
 
   IConfigurable
   (config [_]

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -54,6 +54,10 @@
     [_]
     (source-topics streams-builder))
 
+  (with-state-store
+    [_ store-config]
+    (with-state-store streams-builder store-config))
+
   (streams-builder*
     [_]
     (streams-builder* streams-builder))
@@ -257,7 +261,7 @@
      (select-key kstream key-value-mapper-fn)))
 
   (transform
-      [this transformer-supplier-fn]
+    [this transformer-supplier-fn]
     (transform this transformer-supplier-fn []))
 
   (transform
@@ -266,8 +270,18 @@
      config
      (transform kstream transformer-supplier-fn state-store-names)))
 
+  (flat-transform
+    [this transformer-supplier-fn]
+    (flat-transform this transformer-supplier-fn []))
+
+  (flat-transform
+    [_ transformer-supplier-fn state-store-names]
+    (configured-kstream
+     config
+     (flat-transform kstream transformer-supplier-fn state-store-names)))
+
   (transform-values
-      [this value-transformer-supplier-fn]
+    [this value-transformer-supplier-fn]
     (transform-values this value-transformer-supplier-fn []))
 
   (transform-values
@@ -275,6 +289,16 @@
     (configured-kstream
      config
      (transform-values kstream value-transformer-supplier-fn state-store-names)))
+
+  (flat-transform-values
+    [this value-transformer-supplier-fn]
+    (flat-transform-values this value-transformer-supplier-fn []))
+
+  (flat-transform-values
+    [_ value-transformer-supplier-fn state-store-names]
+    (configured-kstream
+     config
+     (flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
 
   (left-join-global
     [_ global-ktable kv-mapper joiner]

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -334,6 +334,26 @@
      (.selectKey ^KStream kstream
                  ^KeyValueMapper (select-key-value-mapper select-key-value-mapper-fn))))
 
+  (join-global
+    [_ global-ktable key-value-mapper-fn joiner-fn]
+    (clj-kstream
+     (.join kstream
+            ^GlobalKTable (global-ktable* global-ktable)
+            ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
+            ^ValueJoiner (value-joiner joiner-fn))))
+
+  (left-join-global
+    [_ global-ktable key-value-mapper-fn joiner-fn]
+    (clj-kstream
+     (.leftJoin kstream
+                ^GlobalKTable (global-ktable* global-ktable)
+                ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
+                ^ValueJoiner (value-joiner joiner-fn))))
+
+  (kstream* [_]
+    kstream)
+
+  ITransformingKStream
   (transform
     [this transformer-supplier-fn]
     (transform this transformer-supplier-fn []))
@@ -380,26 +400,7 @@
      (.flatTransformValues ^KStream kstream
                            ^ValueTransformerSupplier (value-transformer-supplier value-transformer-supplier-fn)
                            ^"[Ljava.lang.String;" (into-array String
-                                                              (clojure.core/map name state-store-names)))))
-
-  (join-global
-    [_ global-ktable key-value-mapper-fn joiner-fn]
-    (clj-kstream
-     (.join kstream
-            ^GlobalKTable (global-ktable* global-ktable)
-            ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
-            ^ValueJoiner (value-joiner joiner-fn))))
-
-  (left-join-global
-    [_ global-ktable key-value-mapper-fn joiner-fn]
-    (clj-kstream
-     (.leftJoin kstream
-                ^GlobalKTable (global-ktable* global-ktable)
-                ^KeyValueMapper (select-key-value-mapper key-value-mapper-fn)
-                ^ValueJoiner (value-joiner joiner-fn))))
-
-  (kstream* [_]
-    kstream))
+                                                              (clojure.core/map name state-store-names))))))
 
 (defn clj-kstream
   "Makes a CljKStream object."

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -119,3 +119,10 @@
   {:topic-name topic-name
    :key-serde (Serdes/Long)
    :value-serde (Serdes/Long)})
+
+(defn string-topic
+  "Helper to create a topic."
+  [topic-name]
+  {:topic-name topic-name
+   :key-serde (Serdes/Long)
+   :value-serde (Serdes/String)})

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -31,6 +31,13 @@
     [topology-builder]
     "Gets the names of source topics for the topology.")
 
+  (with-state-store
+    [topology-builder store-config]
+    "Adds a persistent state store to the topology with the configured name
+    and serdes.
+
+    ```(with-state-store builder {:store-name ... :key-serde ... :value-serde ...}```")
+
   (streams-builder*
     [streams-builder]
     "Returns the underlying KStreamBuilder."))
@@ -166,11 +173,23 @@
     "Creates a KStream that consists of the results of applying the transformer
     to each key/value in the input stream.")
 
+  (flat-transform
+    [kstream transformer-supplier-fn]
+    [kstream transformer-supplier-fn state-store-names]
+    "Creates a KStream that consists of the results of applying the transformer
+    to each key/value in the input stream via flatTransform.")
+
   (transform-values
     [kstream value-transformer-supplier-fn]
     [kstream value-transformer-supplier-fn state-store-names]
     "Creates a KStream that consists of the results of applying the transformer
     to each value in the input stream.")
+
+  (flat-transform-values
+    [kstream value-transformer-supplier-fn]
+    [kstream value-transformer-supplier-fn state-store-names]
+    "Creates a KStream that consists of the results of applying the transformer
+    to each key/value in the input stream via flatTransformValues.")
 
   (join-global
     [kstream global-ktable kv-mapper joiner])

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -167,6 +167,17 @@
 
     ```(fn [[k v]] (* 10 k))```")
 
+  (join-global
+    [kstream global-ktable kv-mapper joiner])
+
+  (left-join-global
+    [kstream global-ktable kv-mapper joiner])
+
+  (kstream*
+    [kstream]
+    "Returns the underlying KStream object."))
+
+(defprotocol ITransformingKStream
   (transform
     [kstream transformer-supplier-fn]
     [kstream transformer-supplier-fn state-store-names]
@@ -189,17 +200,7 @@
     [kstream value-transformer-supplier-fn]
     [kstream value-transformer-supplier-fn state-store-names]
     "Creates a KStream that consists of the results of applying the transformer
-    to each key/value in the input stream via flatTransformValues.")
-
-  (join-global
-    [kstream global-ktable kv-mapper joiner])
-
-  (left-join-global
-    [kstream global-ktable kv-mapper joiner])
-
-  (kstream*
-    [kstream]
-    "Returns the underlying KStream object."))
+    to each key/value in the input stream via flatTransformValues."))
 
 (defprotocol IKTable
   "A Ktable is an abstraction of a changlog stream."

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -7,7 +7,7 @@
             [jackdaw.streams.lambdas :as lambdas]
             [jackdaw.streams.protocols
              :refer [IStreamsBuilder IGlobalKTable IKGroupedTable
-                     IKGroupedStream IKStream IKTable
+                     IKGroupedStream IKStream IKTable ITransformingKStream
                      ITimeWindowedKStream ISessionWindowedKStream]])
   (:import org.apache.kafka.common.serialization.Serde
            org.apache.kafka.streams.kstream.JoinWindows))
@@ -33,7 +33,9 @@
   (partial satisfies? IKGroupedTable))
 
 (def kstream?
-  (partial satisfies? IKStream))
+  (fn [thing]
+    (and (satisfies? IKStream thing)
+         (satisfies? ITransformingKStream thing))))
 
 (def ktable?
   (partial satisfies? IKTable))
@@ -228,18 +230,6 @@
                      :select-key-value-mapper-fn ifn?)
         :ret kstream?)
 
-(s/fdef k/transform
-        :args (s/cat :kstream kstream?
-                     :transformer-supplier-fn ifn?
-                     :state-store-names (s/? (s/coll-of string?)))
-        :ret kstream?)
-
-(s/fdef k/transform-values
-        :args (s/cat :kstream kstream?
-                     :value-transformer-supplier-fn ifn?
-                     :state-store-names (s/? (s/coll-of string?)))
-        :ret kstream?)
-
 (s/fdef k/join-global
         :args (s/cat :kstream kstream?
                      :global-ktable global-ktable?
@@ -256,6 +246,32 @@
 
 (s/fdef k/kstream*
         :args (s/cat :kstream kstream?)
+        :ret kstream?)
+
+;; ITransformingKStream
+
+(s/fdef k/transform
+        :args (s/cat :kstream kstream?
+                     :transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
+        :ret kstream?)
+
+(s/fdef k/flat-transform
+        :args (s/cat :kstream kstream?
+                     :transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
+        :ret kstream?)
+
+(s/fdef k/transform-values
+        :args (s/cat :kstream kstream?
+                     :value-transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
+        :ret kstream?)
+
+(s/fdef k/flat-transform-values
+        :args (s/cat :kstream kstream?
+                     :value-transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
         :ret kstream?)
 
 ;; IKTable

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -10,7 +10,7 @@
             [jackdaw.streams.lambdas.specs]
             [jackdaw.streams.mock :as mock]
             [jackdaw.streams.protocols
-             :refer [IKStream IKTable IStreamsBuilder]]
+             :refer [IKStream IKTable IStreamsBuilder ITransformingKStream]]
             [jackdaw.streams.specs])
   (:import [java.time Duration]
            [org.apache.kafka.streams.kstream
@@ -35,7 +35,8 @@
           kstream-a (-> streams-builder
                         (k/kstream (mock/topic "topic-a")))]
 
-      (is (satisfies? IKStream kstream-a))))
+      (is (and (satisfies? IKStream kstream-a)
+               (satisfies? ITransformingKStream kstream-a)))))
 
   (testing "kstreams"
     (let [streams-builder (mock/streams-builder)
@@ -43,7 +44,8 @@
                       (k/kstreams [(mock/topic "topic-a")
                                    (mock/topic "topic-b")]))]
 
-      (is (satisfies? IKStream kstream))))
+      (is (and (satisfies? IKStream kstream)
+               (satisfies? ITransformingKStream kstream)))))
 
   (testing "ktable"
     (let [streams-builder (mock/streams-builder)


### PR DESCRIPTION
Spotted [flatTransform](https://kafka.apache.org/23/javadoc/org/apache/kafka/streams/kstream/KStream.html#flatTransform-org.apache.kafka.streams.kstream.TransformerSupplier-java.lang.String...- ) for a KStream and it looks worth adding. Also added a few of the common bits of wrapper / helper / sugar code which pop up from uses of transformers.

* Add support for flat-transform and flat-transform-values
* Add some helpers for adding state stores
* Add some sugar for common transform use cases
* Use some of the above to provide simple de-duping stream support in extras

With `flatTransformValues` note that if you return an empty list or nil, it halts processing. With `transformValues`, if you return nil processing is *not* halted and the next processor in the stream sees [k nil]. This difference can be useful if you _meant_ to halt processing, as it avoids a subsequent filter.

@creese We really need to get your transducers changes merged too!