### PR TITLE
Fixes* every reflection warning

### DIFF
--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -9,8 +9,11 @@
   (:require
    [jackdaw.data :as jd]
    [manifold.deferred :as d])
-  (:import [org.apache.kafka.clients.admin AdminClient
+  (:import [java.util Properties]
+           [org.apache.kafka.clients.admin AdminClient
             DescribeTopicsOptions DescribeClusterOptions DescribeConfigsOptions]))
+
+(set! *warn-on-reflection* true)
 
 (defprotocol Client
   (alter-topics* [this topics])
@@ -24,25 +27,25 @@
 (def client-impl
   {:alter-topics* (fn [this topics]
                     (d/future
-                      @(.all (.alterConfigs this topics))))
+                      @(.all (.alterConfigs ^AdminClient this topics))))
    :create-topics* (fn [this topics]
                     (d/future
-                      @(.all (.createTopics this topics))))
+                      @(.all (.createTopics ^AdminClient this topics))))
    :delete-topics*  (fn [this topics]
                       (d/future
-                        @(.all (.deleteTopics this topics))))
+                        @(.all (.deleteTopics ^AdminClient this topics))))
    :describe-topics* (fn [this topics]
                        (d/future
-                         @(.all (.describeTopics this topics (DescribeTopicsOptions.)))))
+                         @(.all (.describeTopics ^AdminClient this topics (DescribeTopicsOptions.)))))
    :describe-configs* (fn [this configs]
                         (d/future
-                          @(.all (.describeConfigs this configs (DescribeConfigsOptions.)))))
+                          @(.all (.describeConfigs ^AdminClient this configs (DescribeConfigsOptions.)))))
    :describe-cluster* (fn [this]
                         (d/future
-                          (jd/datafy (.describeCluster this (DescribeClusterOptions.)))))
+                          (jd/datafy (.describeCluster ^AdminClient this (DescribeClusterOptions.)))))
    :list-topics* (fn [this]
                    (d/future
-                     @(.names (.listTopics this))))})
+                     @(.names (.listTopics ^AdminClient this))))})
 
 (extend AdminClient
   Client
@@ -53,7 +56,7 @@
   an `AdminClient` bootstrapped off of the configured servers."
   ^AdminClient [kafka-config]
   {:pre [(get kafka-config "bootstrap.servers")]}
-  (AdminClient/create (jd/map->Properties kafka-config)))
+  (AdminClient/create ^Properties (jd/map->Properties kafka-config)))
 
 (defn client?
   "Predicate.

--- a/src/jackdaw/client.clj
+++ b/src/jackdaw/client.clj
@@ -29,9 +29,9 @@
 (defn ^KafkaProducer producer
   "Return a producer with the supplied properties and optional Serdes."
   ([config]
-   (KafkaProducer. (jd/map->Properties config)))
+   (KafkaProducer. ^java.util.Properties (jd/map->Properties config)))
   ([config {:keys [^Serde key-serde ^Serde value-serde]}]
-   (KafkaProducer. (jd/map->Properties config)
+   (KafkaProducer. ^java.util.Properties (jd/map->Properties config)
                    (.serializer key-serde)
                    (.serializer value-serde))))
 
@@ -92,7 +92,7 @@
 (defn ^KafkaConsumer consumer
   "Return a consumer with the supplied properties and optional Serdes."
   ([config]
-   (KafkaConsumer. (jd/map->Properties config)))
+   (KafkaConsumer. ^java.util.Properties (jd/map->Properties config)))
   ([config {:keys [^Serde key-serde ^Serde value-serde] :as t}]
 
    (when-not (or key-serde
@@ -106,7 +106,7 @@
                      {:topic t, :config config})))
 
    (KafkaConsumer.
-    (jd/map->Properties config)
+    ^java.util.Properties (jd/map->Properties config)
     (when key-serde
       (.deserializer key-serde))
     (when value-serde
@@ -208,8 +208,8 @@
 
   Returns the consumer for convenience with `->`, `doto` etc."
   [^Consumer consumer topic-partition ^long offset]
-  (doto consumer
-    (.seek (jd/as-TopicPartition topic-partition) offset)))
+  (doto ^Consumer consumer
+    (.seek ^TopicPartition (jd/as-TopicPartition topic-partition) offset)))
 
 (defn seek-to-end-eager
   "Seek to the last offset for all assigned partitions, and force positioning.

--- a/src/jackdaw/client/log.clj
+++ b/src/jackdaw/client/log.clj
@@ -7,6 +7,8 @@
             [jackdaw.client :as jc])
   (:import org.apache.kafka.clients.consumer.Consumer))
 
+(set! *warn-on-reflection* true)
+
 (defn log
   "Given a consumer, returns a lazy sequence of datafied consumer records.
 

--- a/src/jackdaw/client/partitioning.clj
+++ b/src/jackdaw/client/partitioning.clj
@@ -40,6 +40,8 @@
            org.apache.kafka.common.serialization.Serde
            org.apache.kafka.common.utils.Utils))
 
+(set! *warn-on-reflection* true)
+
 (defn record-key->key-fn
   "Given a topic config having `:record-key`, parse it,
   annotating the topic with a `:Lkey-fn` which will simply fetch the

--- a/src/jackdaw/data/admin.clj
+++ b/src/jackdaw/data/admin.clj
@@ -4,6 +4,8 @@
           Config ConfigEntry DescribeClusterResult NewTopic
           TopicDescription])
 
+(set! *warn-on-reflection* true)
+
 ;;; ConfigEntry
 
 (defn ->ConfigEntry

--- a/src/jackdaw/data/common.clj
+++ b/src/jackdaw/data/common.clj
@@ -5,6 +5,8 @@
           Node TopicPartition TopicPartitionInfo])
 
 
+(set! *warn-on-reflection* true)
+
 ;;; Node
 
 (defn->data Node->data

--- a/src/jackdaw/data/common_config.clj
+++ b/src/jackdaw/data/common_config.clj
@@ -3,6 +3,8 @@
 (import '[org.apache.kafka.common.config
           ConfigResource ConfigResource$Type])
 
+(set! *warn-on-reflection* true)
+
 ;;; ConfigResource.Type
 
 (def +broker-config-resource-type+

--- a/src/jackdaw/data/common_record.clj
+++ b/src/jackdaw/data/common_record.clj
@@ -2,6 +2,8 @@
 
 (import 'org.apache.kafka.common.record.TimestampType)
 
+(set! *warn-on-reflection* true)
+
 ;;; Timestamp types
 
 (def +no-type-timestamp+

--- a/src/jackdaw/data/consumer.clj
+++ b/src/jackdaw/data/consumer.clj
@@ -8,6 +8,8 @@
           ConsumerRecord OffsetAndTimestamp]
         'org.apache.kafka.common.header.Headers)
 
+(set! *warn-on-reflection* true)
+
 (defn ^ConsumerRecord ->ConsumerRecord
   "Given unrolled ctor-style arguments create a Kafka `ConsumerRecord`.
 

--- a/src/jackdaw/data/producer.clj
+++ b/src/jackdaw/data/producer.clj
@@ -8,6 +8,8 @@
           ProducerRecord RecordMetadata]
         'org.apache.kafka.common.header.Headers)
 
+(set! *warn-on-reflection* true)
+
 ;;; Producer record
 
 (defn ^ProducerRecord ->ProducerRecord

--- a/src/jackdaw/serdes.clj
+++ b/src/jackdaw/serdes.clj
@@ -7,6 +7,8 @@
             [jackdaw.serdes.fressian :as jsf])
   (:import org.apache.kafka.common.serialization.Serdes))
 
+(set! *warn-on-reflection* true)
+
 (defn string-serde
   []
   (Serdes/String))

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -442,7 +442,7 @@
                               {:path path, :clj-data clj-map})))
             (let [[_ field-coercion] (get field->schema+coercion k)
                   new-v (clj->avro field-coercion v (conj path k))]
-              (.set record-builder new-k new-v))))
+              (.set record-builder ^String new-k new-v))))
 
         (.build record-builder)
 
@@ -525,7 +525,7 @@
                                                  (assoc :topic topic :clj-data data))]
                                     (throw (ex-info (.getMessage e) data))))))}
         clj-serializer (fn/new-serializer methods)]
-    (.configure clj-serializer (base-config registry-url) key?)
+    (.configure ^Serializer clj-serializer (base-config registry-url) key?)
     clj-serializer))
 
 (defn- deserializer [schema->coercion serde-config]
@@ -560,7 +560,7 @@
                                       (log/error e (str msg " for " topic))
                                       (throw (ex-info msg {:topic topic} e))))))}
         clj-deserializer (fn/new-deserializer methods)]
-    (.configure clj-deserializer (base-config registry-url) key?)
+    (.configure ^Deserializer clj-deserializer (base-config registry-url) key?)
     clj-deserializer))
 
 ;; Public API

--- a/src/jackdaw/serdes/avro/confluent.clj
+++ b/src/jackdaw/serdes/avro/confluent.clj
@@ -1,6 +1,8 @@
 (ns jackdaw.serdes.avro.confluent
   (:require [jackdaw.serdes.avro :as jsa]))
 
+(set! *warn-on-reflection* true)
+
 (defn serde
   "Creates a serde for Avro data. An avro serde needs to know if its generating
   a key or value in the data (a separate serde is required for each as a result).

--- a/src/jackdaw/serdes/avro/schema_registry.clj
+++ b/src/jackdaw/serdes/avro/schema_registry.clj
@@ -5,6 +5,8 @@
             MockSchemaRegistryClient
             CachedSchemaRegistryClient]))
 
+(set! *warn-on-reflection* true)
+
 (defn client
   "Build and return a Kafka Schema Registry client which uses an LRU
   strategy to cache the specified number of schemas."

--- a/src/jackdaw/serdes/fn.clj
+++ b/src/jackdaw/serdes/fn.clj
@@ -5,6 +5,8 @@
             [jackdaw.serdes.fn-impl :as fn-impl])
   (:import [org.apache.kafka.common.serialization Deserializer Serializer]))
 
+(set! *warn-on-reflection* true)
+
 (s/def ::serialize fn?)
 (s/def ::close fn?)
 (s/def ::configure fn?)

--- a/src/jackdaw/serdes/fn_impl.clj
+++ b/src/jackdaw/serdes/fn_impl.clj
@@ -4,6 +4,8 @@
   (:import [org.apache.kafka.common.serialization
             Deserializer Serdes Serializer]))
 
+(set! *warn-on-reflection* true)
+
 ;; Kafka requires serdes to load from their own classloader, which
 ;; requires AOT. We don't want to transitively AOT other libs such as
 ;; tools.reader.edn, or nippy, etc, so provide a dumb box that we can

--- a/src/jackdaw/serdes/resolver.clj
+++ b/src/jackdaw/serdes/resolver.clj
@@ -8,6 +8,8 @@
             [jackdaw.serdes]
             [jackdaw.specs]))
 
+(set! *warn-on-reflection* true)
+
 (defn load-schema
   "Takes a serde config and loads the schema from the classpath."
   [{:keys [schema-filename] :as serde-config}]

--- a/src/jackdaw/specs.clj
+++ b/src/jackdaw/specs.clj
@@ -2,6 +2,8 @@
   "Specs for `jackdaw`"
   (:require [clojure.spec.alpha :as s]))
 
+(set! *warn-on-reflection* true)
+
 ;; The basic topic
 
 (s/def ::topic-name

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -10,6 +10,8 @@
            org.apache.kafka.streams.KafkaStreams$State
            org.apache.kafka.streams.Topology))
 
+(set! *warn-on-reflection* true)
+
 ;; StreamsBuilder
 
 (defn kstream
@@ -315,7 +317,7 @@
   ([builder opts]
    (let [props (java.util.Properties.)]
      (.putAll props opts)
-     (KafkaStreams. ^Topology (.build (streams-builder* builder))
+     (KafkaStreams. ^Topology (.build ^StreamsBuilder (streams-builder* builder))
                     ^java.util.Properties props))))
 
 (defn start

--- a/src/jackdaw/streams/configurable.clj
+++ b/src/jackdaw/streams/configurable.clj
@@ -2,6 +2,8 @@
   "Protocol for a configurable thing."
   {:license "BSD 3-Clause License <https://github.com/FundingCircle/jackdaw/blob/master/LICENSE>"})
 
+(set! *warn-on-reflection* true)
+
 (defprotocol IConfigurable
   (config [_] "Gets the configuration.")
   (configure [_ key value] "Adds a configuration."))

--- a/src/jackdaw/streams/configured.clj
+++ b/src/jackdaw/streams/configured.clj
@@ -5,6 +5,8 @@
   (:require [jackdaw.streams.protocols :refer :all]
             [jackdaw.streams.configurable :refer [config IConfigurable]]))
 
+(set! *warn-on-reflection* true)
+
 (declare configured-kstream configured-ktable configured-global-ktable
          configured-kgroupedtable configured-kgroupedstream
          configured-time-windowed-kstream

--- a/src/jackdaw/streams/extras.clj
+++ b/src/jackdaw/streams/extras.clj
@@ -8,6 +8,8 @@
   (:import org.apache.kafka.common.TopicPartition
            org.apache.kafka.streams.processor.StateRestoreListener))
 
+(set! *warn-on-reflection* true)
+
 (defn map-validating!
   [builder topic topic-spec {:keys [line file]}]
   (js/map-values builder

--- a/src/jackdaw/streams/lambdas.clj
+++ b/src/jackdaw/streams/lambdas.clj
@@ -9,6 +9,8 @@
            [org.apache.kafka.streams.processor
             Processor ProcessorSupplier StreamPartitioner]))
 
+(set! *warn-on-reflection* true)
+
 (defn key-value
   "A key-value pair defined for a single Kafka Streams record."
   [[key value]]

--- a/src/jackdaw/streams/lambdas/specs.clj
+++ b/src/jackdaw/streams/lambdas/specs.clj
@@ -6,6 +6,8 @@
   (:import [org.apache.kafka.streams.kstream
             Aggregator Initializer Merger]))
 
+(set! *warn-on-reflection* true)
+
 (def initializer? (partial instance? Initializer))
 (def aggregator? (partial instance? Aggregator))
 (def merger? (partial instance? Merger))

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -15,6 +15,8 @@
            org.apache.kafka.common.header.internals.RecordHeaders
            [org.apache.kafka.common.serialization Serde Serdes Serializer]))
 
+(set! *warn-on-reflection* false)
+
 (defn streams-builder
   "Creates a mock streams-builder."
   ([]

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -5,6 +5,8 @@
   (:import org.apache.kafka.streams.KafkaStreams
            org.apache.kafka.streams.StreamsBuilder))
 
+(set! *warn-on-reflection* true)
+
 (defprotocol IStreamsBuilder
   (kstream
     [topology-builder topic-config]

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -12,6 +12,8 @@
   (:import org.apache.kafka.common.serialization.Serde
            org.apache.kafka.streams.kstream.JoinWindows))
 
+(set! *warn-on-reflection* true)
+
 (def global-ktable?
   (partial satisfies? IGlobalKTable))
 

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -33,8 +33,11 @@
    [jackdaw.test.journal :refer [with-journal]]
    [jackdaw.test.middleware :refer [with-timing with-status with-journal-snapshots]])
   (:import
+   (java.io Closeable)
    (java.util Properties)
-   (org.apache.kafka.streams TopologyTestDriver)))
+   (org.apache.kafka.streams TopologyTestDriver StreamsBuilder)))
+
+(set! *warn-on-reflection* true)
 
 ;; Information about the internal architecture. Extract this out to a wiki or
 ;; something.
@@ -227,20 +230,20 @@
                 (actual-topic-output journal))))))
    ```"
   [transport f]
-  (with-open [machine (test-machine transport)]
+  (with-open [machine ^TestMachine (test-machine transport)]
     (f machine)))
 
 (defn- set-properties
   [properties m]
   (doseq [[k v] m]
-    (.setProperty properties k v))
+    (.setProperty ^Properties properties k v))
   properties)
 
 (defn mock-test-driver
   [build-fn app-config]
   (let [builder (k/streams-builder)
         topology (let [builder (build-fn builder)]
-                   (-> (k/streams-builder* builder)
+                   (-> ^StreamsBuilder (k/streams-builder* builder)
                        .build))
         props (-> (Properties.)
                   (set-properties app-config))]

--- a/src/jackdaw/test/commands.clj
+++ b/src/jackdaw/test/commands.clj
@@ -7,6 +7,8 @@
    [jackdaw.test.commands.watch :as watch])
   (:refer-clojure :exclude [do]))
 
+(set! *warn-on-reflection* true)
+
 (def base-commands base/command-map)
 (def write-command write/command-map)
 (def watch-command watch/command-map)

--- a/src/jackdaw/test/commands/base.clj
+++ b/src/jackdaw/test/commands/base.clj
@@ -2,6 +2,8 @@
   (:require
    [clojure.pprint :as pprint]))
 
+(set! *warn-on-reflection* true)
+
 (def command-map
   {:stop (constantly true)
 

--- a/src/jackdaw/test/commands/watch.clj
+++ b/src/jackdaw/test/commands/watch.clj
@@ -3,6 +3,8 @@
    [jackdaw.test.journal :as j]
    [clojure.tools.logging :as log]))
 
+(set! *warn-on-reflection* true)
+
 ;; Circle CI times out after a minute, so make sure this is less than 60,000
 (def ^:dynamic *default-watch-timeout* 10000)
 

--- a/src/jackdaw/test/commands/write.clj
+++ b/src/jackdaw/test/commands/write.clj
@@ -4,6 +4,8 @@
    [clojure.tools.logging :as log]
    [jackdaw.client.partitioning :as partitioning]))
 
+(set! *warn-on-reflection* true)
+
 (defn default-partition-fn [topic-map topic-name k v partition-count]
   (int (partitioning/default-partition topic-map k nil partition-count)))
 

--- a/src/jackdaw/test/journal.clj
+++ b/src/jackdaw/test/journal.clj
@@ -6,6 +6,8 @@
     [manifold.stream :as s]
     [manifold.deferred :as d]))
 
+(set! *warn-on-reflection* true)
+
 ;; Journal
 ;;
 ;; The journal represents the test output. It captures the output of all

--- a/src/jackdaw/test/middleware.clj
+++ b/src/jackdaw/test/middleware.clj
@@ -2,6 +2,8 @@
   "A test machine executor can be built by composing execution wrappers
    defined in here")
 
+(set! *warn-on-reflection* true)
+
 (defn with-status
   [f]
   (fn [machine cmd]

--- a/src/jackdaw/test/serde.clj
+++ b/src/jackdaw/test/serde.clj
@@ -11,6 +11,8 @@
    (org.apache.kafka.common.errors SerializationException)))
 
 
+(set! *warn-on-reflection* false)
+
 ;; Access to various serdes
 
 (defn resolver [topic-config]

--- a/src/jackdaw/test/transports.clj
+++ b/src/jackdaw/test/transports.clj
@@ -1,5 +1,7 @@
 (ns jackdaw.test.transports)
 
+(set! *warn-on-reflection* true)
+
 (defonce +transports+ (atom #{}))
 
 (defmulti transport :type)

--- a/src/jackdaw/test/transports/identity.clj
+++ b/src/jackdaw/test/transports/identity.clj
@@ -4,6 +4,8 @@
    [manifold.stream :as s]
    [jackdaw.test.transports :as t :refer [deftransport]]))
 
+(set! *warn-on-reflection* true)
+
 (defn identity-consumer
   [stream]
   (let [started? (promise)]

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -12,6 +12,8 @@
    (org.apache.kafka.common.record TimestampType)
    (org.apache.kafka.clients.consumer ConsumerRecord)))
 
+(set! *warn-on-reflection* false)
+
 ;; Unfortunately the terminology used in the test-machine clashes a bit with
 ;; the terminology used by the TopologyTestDriver so this looks a bit
 ;; confusing.

--- a/src/jackdaw/test/transports/rest_proxy.clj
+++ b/src/jackdaw/test/transports/rest_proxy.clj
@@ -13,6 +13,8 @@
   (:import
    (java.util UUID Base64)))
 
+(set! *warn-on-reflection* false)
+
 (def ^:dynamic *http-client*
   {:post    http/post
    :get     http/get

--- a/test/jackdaw/admin_test.clj
+++ b/test/jackdaw/admin_test.clj
@@ -8,6 +8,8 @@
    (org.apache.kafka.common Node KafkaFuture)
    (org.apache.kafka.clients.admin MockAdminClient)))
 
+(set! *warn-on-reflection* false)
+
 (extend MockAdminClient
   admin/Client
   (-> admin/client-impl

--- a/test/jackdaw/client/partitioning_test.clj
+++ b/test/jackdaw/client/partitioning_test.clj
@@ -4,6 +4,8 @@
    [jackdaw.client :as client]
    [jackdaw.client.partitioning :as part]))
 
+(set! *warn-on-reflection* false)
+
 (deftest test-record-key->key-fn
   (let [test-key-fn (fn [key-str]
                       (-> (part/record-key->key-fn {:record-key key-str})

--- a/test/jackdaw/client_test.clj
+++ b/test/jackdaw/client_test.clj
@@ -11,6 +11,8 @@
            [org.apache.kafka.clients.producer Producer]
            org.apache.kafka.common.TopicPartition))
 
+(set! *warn-on-reflection* false)
+
 (def foo-topic
   (serde/resolver {:topic-name "foo"
                    :replication-factor 1

--- a/test/jackdaw/data_test.clj
+++ b/test/jackdaw/data_test.clj
@@ -8,6 +8,8 @@
            [org.apache.kafka.common.header
             Headers Header]))
 
+(set! *warn-on-reflection* false)
+
 (deftest producer-record-arity-2
   (are [topic-config value]
       (instance? ProducerRecord

--- a/test/jackdaw/serdes/avro/integration_test.clj
+++ b/test/jackdaw/serdes/avro/integration_test.clj
@@ -13,6 +13,8 @@
            [org.apache.avro.generic GenericData$Record]
            [org.apache.kafka.common.serialization Serde Serdes]))
 
+(set! *warn-on-reflection* false)
+
 (def +real-schema-registry-url+
   "http://localhost:8081")
 

--- a/test/jackdaw/serdes/avro/uuid_test.clj
+++ b/test/jackdaw/serdes/avro/uuid_test.clj
@@ -7,6 +7,8 @@
            (org.apache.avro.generic GenericData$Record)
            (org.apache.avro.util Utf8)))
 
+(set! *warn-on-reflection* false)
+
 (def +registry+
   (merge avro/+base-schema-type-registry+
          avro/+UUID-type-registry+))

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -13,6 +13,8 @@
             GenericData$EnumSymbol GenericData$Record GenericData$Array]
            [org.apache.avro.util Utf8]))
 
+(set! *warn-on-reflection* false)
+
 (defn parse-schema [clj-schema]
   (.parse (Schema$Parser.) ^String (json/write-str clj-schema)))
 

--- a/test/jackdaw/serdes/edn2_test.clj
+++ b/test/jackdaw/serdes/edn2_test.clj
@@ -6,6 +6,8 @@
             [clojure.test.check.properties :as prop]
             [jackdaw.serdes.edn2 :as jse]))
 
+(set! *warn-on-reflection* false)
+
 (defspec edn-roundtrip-test 20
   (testing "EDN data is the same after serialization and deserialization."
     (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]

--- a/test/jackdaw/serdes/edn_test.clj
+++ b/test/jackdaw/serdes/edn_test.clj
@@ -6,6 +6,8 @@
             [clojure.test.check.properties :as prop]
             [jackdaw.serdes.edn :as jse]))
 
+(set! *warn-on-reflection* false)
+
 (defspec edn-roundtrip-test 20
   (testing "EDN data is the same after serialization and deserialization."
     (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]

--- a/test/jackdaw/serdes/fressian_test.clj
+++ b/test/jackdaw/serdes/fressian_test.clj
@@ -9,6 +9,8 @@
   (:import java.net.URI
            [org.fressian.handlers WriteHandler ReadHandler]))
 
+(set! *warn-on-reflection* false)
+
 (defspec fressian-roundtrip-test 20
   (testing "Fressian data is the same after serialization and deserialization."
     (prop/for-all [x (gen/fmap #(apply str %) (gen/vector gen/char-alpha 100))]

--- a/test/jackdaw/serdes/json_test.clj
+++ b/test/jackdaw/serdes/json_test.clj
@@ -7,6 +7,8 @@
             [clojure.test.check.properties :as prop]
             [jackdaw.serdes.json :as jsj]))
 
+(set! *warn-on-reflection* false)
+
 (def string-bytes-roundtrip-property
   "A strings `s' should be the same after writing to a byte array and reading
   back as a string."

--- a/test/jackdaw/serdes/resolver_test.clj
+++ b/test/jackdaw/serdes/resolver_test.clj
@@ -12,6 +12,8 @@
            (org.apache.kafka.common.serialization Serde)))
 
 
+(set! *warn-on-reflection* false)
+
 (deftest load-schema-test
   (testing "a schema can be loaded"
     (is (not (nil? (resolver/load-schema {:schema-filename "resources/example_schema.avsc"})))))

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -18,6 +18,8 @@
            org.apache.kafka.streams.StreamsBuilder
            [org.apache.kafka.common.serialization Serdes]))
 
+(set! *warn-on-reflection* false)
+
 (stest/instrument)
 
 (defn close-test-driver [cfg-topology]

--- a/test/jackdaw/test/commands/base_test.clj
+++ b/test/jackdaw/test/commands/base_test.clj
@@ -4,6 +4,8 @@
    [clojure.pprint :as pprint]
    [clojure.test :refer :all]))
 
+(set! *warn-on-reflection* false)
+
 (deftest test-base-commands
   (testing "stop"
     (is ((cmd/command-map :stop) {})))

--- a/test/jackdaw/test/commands/watch_test.clj
+++ b/test/jackdaw/test/commands/watch_test.clj
@@ -4,6 +4,8 @@
    [manifold.deferred :as d]
    [clojure.test :refer [deftest testing is]]))
 
+(set! *warn-on-reflection* false)
+
 ;; An example of the problem the watcher is trying to solve
 ;; might help.
 ;;

--- a/test/jackdaw/test/commands/write_test.clj
+++ b/test/jackdaw/test/commands/write_test.clj
@@ -9,6 +9,8 @@
   (:import
     [clojure.lang ExceptionInfo]))
 
+(set! *warn-on-reflection* false)
+
 (def foo-topic
   (serde/resolver {:topic-name "foo"
                    :replication-factor 1

--- a/test/jackdaw/test/commands_test.clj
+++ b/test/jackdaw/test/commands_test.clj
@@ -3,6 +3,8 @@
    [clojure.test :refer :all]
    [jackdaw.test.commands :as cmd]))
 
+(set! *warn-on-reflection* false)
+
 (deftest test-command-handler
   (testing "input cmd and params added into result"
     (let [test-cmd [:stop]]

--- a/test/jackdaw/test/fixtures.clj
+++ b/test/jackdaw/test/fixtures.clj
@@ -15,6 +15,8 @@
    (org.apache.kafka.clients.admin AdminClient NewTopic)
    (org.apache.kafka.streams KafkaStreams$StateListener KafkaStreams$State)))
 
+(set! *warn-on-reflection* false)
+
 ;;; topic-fixture ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn- new-topic

--- a/test/jackdaw/test/fixtures_test.clj
+++ b/test/jackdaw/test/fixtures_test.clj
@@ -6,6 +6,8 @@
   (:import
    (org.apache.kafka.clients.admin AdminClient NewTopic)))
 
+(set! *warn-on-reflection* false)
+
 (def topic-foo
   {:topic-name "foo"
    :partition-count 1

--- a/test/jackdaw/test/journal_test.clj
+++ b/test/jackdaw/test/journal_test.clj
@@ -3,6 +3,8 @@
     [clojure.test :refer :all]
     [jackdaw.test.journal :as jrnl]))
 
+(set! *warn-on-reflection* false)
+
 (deftest journal-access-tests
   (let [j {:topics {"foo" [{:key 1
                             :value {:id 1 :v 99}}

--- a/test/jackdaw/test/middleware_test.clj
+++ b/test/jackdaw/test/middleware_test.clj
@@ -7,6 +7,8 @@
    [jackdaw.test.transports.identity]
    [jackdaw.test :as jd.test]))
 
+(set! *warn-on-reflection* false)
+
 (defn identity-transport
   []
   (trns/transport {:type :identity}))

--- a/test/jackdaw/test/transports/kafka_test.clj
+++ b/test/jackdaw/test/transports/kafka_test.clj
@@ -12,6 +12,8 @@
   (:import
    (java.util Properties)))
 
+(set! *warn-on-reflection* false)
+
 (def kafka-config {"bootstrap.servers" "localhost:9092"
                    "group.id" "kafka-write-test"})
 

--- a/test/jackdaw/test/transports/mock_test.clj
+++ b/test/jackdaw/test/transports/mock_test.clj
@@ -12,6 +12,8 @@
    (java.util Properties)
    (org.apache.kafka.streams TopologyTestDriver)))
 
+(set! *warn-on-reflection* false)
+
 (defmethod print-method TopologyTestDriver [x writer]
   (print-simple x writer))
 

--- a/test/jackdaw/test/transports/rest_proxy_test.clj
+++ b/test/jackdaw/test/transports/rest_proxy_test.clj
@@ -16,6 +16,8 @@
   (:import
    (java.util Properties)))
 
+(set! *warn-on-reflection* false)
+
 (def kafka-config {"bootstrap.servers" "localhost:9092"
                    "group.id" "kafka-write-test"})
 

--- a/test/jackdaw/test_test.clj
+++ b/test/jackdaw/test_test.clj
@@ -12,6 +12,8 @@
    (java.util Properties)
    (org.apache.kafka.streams TopologyTestDriver)))
 
+(set! *warn-on-reflection* false)
+
 (def foo-topic
   (serde/resolver {:topic-name "foo"
                    :replication-factor 1


### PR DESCRIPTION
* For test namespaces, turned off the reflection check
* For all non-test namespaces, enforce the reflection check

Will not be popular if you have an open PR!

Would be good to start failing the build on reflection warnings if we can?