### PR TITLE
Use jd/map->Properties on kafka-streams opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-* Fix `ktable` constructor to use supplied `store-name` 
+* Allow map with keyword keys in streams constructor.
+
+* Fix `ktable` constructor to use supplied `store-name`
 
 ## [0.7.3] - [2020-04-08]
 

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -3,6 +3,7 @@
   {:license "BSD 3-Clause License <https://github.com/FundingCircle/jackdaw/blob/master/LICENSE>"}
   (:refer-clojure :exclude [count map merge reduce group-by filter peek])
   (:require [clojure.string :as str]
+            [jackdaw.data :as jd]
             [jackdaw.streams.interop :as interop]
             [jackdaw.streams.protocols :as p])
   (:import org.apache.kafka.streams.KafkaStreams
@@ -315,10 +316,8 @@
 (defn kafka-streams
   "Makes a Kafka Streams object."
   ([builder opts]
-   (let [props (java.util.Properties.)]
-     (.putAll props opts)
-     (KafkaStreams. ^Topology (.build ^StreamsBuilder (streams-builder* builder))
-                    ^java.util.Properties props))))
+   (KafkaStreams. ^Topology (.build (streams-builder* builder))
+                  (jd/map->Properties opts))))
 
 (defn start
   "Starts processing."


### PR DESCRIPTION
This seems like an oversight, I found it confusing that I had to use string keys.

# Checklist

Not sure how to go about testing this?
- [ ] tests  
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
