### PR TITLE
Add kafka message header support for test machine

### DIFF
--- a/src/jackdaw/test/commands/write.clj
+++ b/src/jackdaw/test/commands/write.clj
@@ -35,7 +35,8 @@
         partn (if-let [explicit-partition (:partition opts)]
                 explicit-partition
                 (partition-fn (:topic-name topic-map) k message (:partition-count topic-map)))
-        timestamp (:timestamp opts (System/currentTimeMillis))]
+        timestamp (:timestamp opts (System/currentTimeMillis))
+        headers (:headers opts)]
     (if (or (< partn 0)
             (> partn (dec (:partition-count topic-map))))
       (throw (ex-info "Invalid partition number for topic"
@@ -45,7 +46,8 @@
        :key k
        :value message
        :partition partn
-       :timestamp timestamp})))
+       :timestamp timestamp
+       :headers headers})))
 
 (defn do-write
   ([machine topic-name message]

--- a/src/jackdaw/test/serde.clj
+++ b/src/jackdaw/test/serde.clj
@@ -86,7 +86,8 @@
      :key (deserialize-key (:key m) topic)
      :value (deserialize-value (:value m) topic)
      :partition (:partition m 0)
-     :offset (:offset m 0)}))
+     :offset (:offset m 0)
+     :headers (:headers m {})}))
 
 (defn deserializers
   "Returns a map of topics to the corresponding deserializer"

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -140,6 +140,12 @@
   (reset! (:continue? consumer) false)
   (deref (:process consumer)))
 
+(defn set-headers [^ProducerRecord producer-record headers]
+  (let [record-headers (.headers producer-record)]
+    (doseq [[k v] headers]
+      (.add record-headers k v)))
+  producer-record)
+
 (defn build-record
   "Builds a Kafka Producer and assoc it onto the message map"
   [m]
@@ -148,6 +154,7 @@
                                 (:timestamp m)
                                 (:key m)
                                 (:value m))]
+    (set-headers rec (:headers m))
     (assoc m :producer-record rec)))
 
 (defn deliver-ack

--- a/src/jackdaw/test/transports/kafka.clj
+++ b/src/jackdaw/test/transports/kafka.clj
@@ -12,6 +12,7 @@
                                serde-map
                                byte-array-serde]])
   (:import
+   org.apache.kafka.common.header.Header
    org.apache.kafka.clients.consumer.Consumer
    org.apache.kafka.streams.KafkaStreams$StateListener
    org.apache.kafka.clients.consumer.ConsumerRecord
@@ -78,7 +79,11 @@
      :serializedValueSize (.serializedValueSize consumer-record)
      :timestamp (.timestamp consumer-record)
      :topic (.topic consumer-record)
-     :value (.value consumer-record)}))
+     :value (.value consumer-record)
+     :headers (reduce (fn [header-map header]
+                        (assoc header-map
+                               (.key ^Header header)
+                               (.value ^Header header))) {} (.headers consumer-record))}))
 
 (defn ^ProducerRecord mk-producer-record
   "Creates a kafka ProducerRecord for use with `send!`."

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -29,9 +29,15 @@
 ;; For this reason, we try to make things a bit more meaningful by using
 ;; terms like "input-record" and "output-record".
 
+(defn set-headers [consumer-record headers]
+  (let [record-headers (.headers consumer-record)]
+    (doseq [[k v] headers]
+      (.add record-headers k v)))
+  consumer-record)
+
 (defn with-input-record
   "Creates a kafka ConsumerRecord to be fed directly into a topology source
-   node by the TopologyTestDriver"
+  node by the TopologyTestDriver"
   [_topic-config]
   (fn [m]
     (let [record (ConsumerRecord. (get-in m [:topic :topic-name])
@@ -48,7 +54,8 @@
                                     0)
                                   (:key m)
                                   (:value m))]
-     (assoc m :input-record record))))
+      (set-headers record (:headers m))
+      (assoc m :input-record record))))
 
 (defn with-output-record
   [_topic-config]
@@ -57,7 +64,6 @@
      :key (.key r)
      :value (.value r)
      :partition (or (.partition r) -1)
-     :matt-was-here true
      :headers (reduce (fn [header-map header]
                         (assoc header-map
                                (.key header)

--- a/src/jackdaw/test/transports/mock.clj
+++ b/src/jackdaw/test/transports/mock.clj
@@ -56,7 +56,12 @@
     {:topic (.topic r)
      :key (.key r)
      :value (.value r)
-     :partition (or (.partition r) -1)}))
+     :partition (or (.partition r) -1)
+     :matt-was-here true
+     :headers (reduce (fn [header-map header]
+                        (assoc header-map
+                               (.key header)
+                               (.value header))) {} (.headers r))}))
 
 (defn- poller
   "Returns a function for polling the results of a TopologyTestDriver

--- a/src/jackdaw/test/transports/rest_proxy.clj
+++ b/src/jackdaw/test/transports/rest_proxy.clj
@@ -210,6 +210,7 @@
   [config topic-metadata deserializers]
   (let [continue?   (atom true)
         xform       (comp
+                     #(assoc % :headers {}) ; cannot read headers over the Rest API
                      #(assoc % :topic (j/reverse-lookup topic-metadata (:topic %)))
                      #(apply-deserializers deserializers %)
                      #(undatafy-record topic-metadata %))


### PR DESCRIPTION
Adds basic support to test machine for reading and writing message headers.
Unfortunately, the Kafka Rest API does not appear to support message headers so its not available there - however the broker and mock transports do support headers.

This is deliberately a light touch Test Machine only change to allow testing and experimentation with the support of headers more widely in Jackdaw, or any topologies tested via Test Machine. No attempt at serdes support is added here, headers must be provided in the form the Java API expects which is a map of:

`String k` -> `byte[] value`

The support does at least let you provide them in a clojure Map. Writes are supported via an additional option for the `:write!` command, e.g.:

`[:write! "my-topic" {:id 1 :message "yolo"} {:headers {"VERSION" (.getBytes "1.0.0")}]`

Any headers read into the journal for a test are captured in the top level structure for each message in the journal, e.g. for the above write you would see:

```
{:topic "my-topic",
 :key 1,
 :value  {:id 1, :message "yolo"},
 :partition 0,
 :offset 0,
 :headers {"VERSION" ...byte array...}}  <<-- headers added here
```

It is left to the user to encode and decode the `byte[]`'s used for headers (as per the Kafka API).

See `test-write-then-read-with-headers ` in `test/jackdaw/test_test.clj` for an end to end example.