### PR TITLE
Add support for schema registry basic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
-* Allow schema-registry client constructor to receive additional config parameters
+ * Allow additional schema-registry client configuration to be passed to:
+   * jackdaw.serdes.avro.schema-registry/client
+   * jackdaw.serdes.resolver/serde-resolver
+   * jackdaw.serdes.avro.confluent/serde
+   * jackdaw.serdes.avro/serde
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+* Allow schema-registry client constructor to receive additional config parameters
+
 ### Fixed
 
 ## [0.7.5] - [2020-07-02] 

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -505,7 +505,7 @@
   {"schema.registry.url" registry-url})
 
 (defn- serializer [schema->coercion serde-config]
-  (let [{:keys [registry-client registry-url avro-schema read-only? key?]} serde-config
+  (let [{:keys [registry-client registry-config avro-schema read-only? key?]} serde-config
         base-serializer (KafkaAvroSerializer. registry-client)
         ;; This is invariant across subject schema changes, shockingly.
         coercion-type (schema->coercion avro-schema)
@@ -525,14 +525,13 @@
                                                  (assoc :topic topic :clj-data data))]
                                     (throw (ex-info (.getMessage e) data))))))}
         clj-serializer (fn/new-serializer methods)]
-    (.configure ^Serializer clj-serializer (base-config registry-url) key?)
+    (.configure ^Serializer clj-serializer registry-config key?)
     clj-serializer))
 
 (defn- deserializer [schema->coercion serde-config]
-  (let [{:keys [registry-client registry-url avro-schema key?
+  (let [{:keys [registry-client registry-config avro-schema key?
                 deserializer-properties]} serde-config
-        base-deserializer (KafkaAvroDeserializer. registry-client (let [min-props {"schema.registry.url" registry-url}]
-                                                                    (merge min-props deserializer-properties)))
+        base-deserializer (KafkaAvroDeserializer. registry-client (merge registry-config deserializer-properties))
         methods {:close       (fn [_]
                                 (.close base-deserializer))
                  :configure   (fn [_ base-config key?]
@@ -560,7 +559,7 @@
                                       (log/error e (str msg " for " topic))
                                       (throw (ex-info msg {:topic topic} e))))))}
         clj-deserializer (fn/new-deserializer methods)]
-    (.configure ^Deserializer clj-deserializer (base-config registry-url) key?)
+    (.configure ^Deserializer clj-deserializer registry-config key?)
     clj-deserializer))
 
 ;; Public API
@@ -670,7 +669,7 @@
   [type-registry
    {:keys [avro.schema-registry/client
            avro.schema-registry/url]
-    :as   registry-config}
+    schema-registry-config :avro.schema-registry/config}
    {:keys [avro/schema
            avro/coercion-cache
            key?
@@ -690,9 +689,9 @@
       ":avro/coercion-cache in the schema config must be either absent/nil, or an atom containing a cache")))
 
   (let [config {:key?            key?
-                :registry-url    url
+                :registry-config (merge (base-config url) schema-registry-config)
                 :registry-client (or client
-                                     (registry/client url 128))
+                                     (registry/client url 128 schema-registry-config))
                 ;; Provide the old behavior by default, or fall through to the
                 ;; new behavior of getting the right schema when possible.
                 :read-only?      read-only?

--- a/src/jackdaw/serdes/avro/confluent.clj
+++ b/src/jackdaw/serdes/avro/confluent.clj
@@ -10,6 +10,7 @@
   serde operation."
   [schema-registry-url schema key? & [{:keys [type-registry
                                               schema-registry-client
+                                              schema-registry-config
                                               coercion-cache
                                               read-only?]}]]
   (let [reg (if (nil? type-registry)
@@ -17,7 +18,8 @@
               type-registry)]
     (jsa/serde reg
                {:avro.schema-registry/url schema-registry-url
-                :avro.schema-registry/client schema-registry-client}
+                :avro.schema-registry/client schema-registry-client
+                :avro.schema-registry/config schema-registry-config}
                {:avro/schema schema
                 :key? key?
                 :avro/coercion-cache coercion-cache

--- a/src/jackdaw/serdes/avro/schema_registry.clj
+++ b/src/jackdaw/serdes/avro/schema_registry.clj
@@ -10,10 +10,12 @@
 (defn client
   "Build and return a Kafka Schema Registry client which uses an LRU
   strategy to cache the specified number of schemas."
-  [^String url max-capacity]
-  {:pre [(string? url)
-         (pos-int? max-capacity)]}
-  (CachedSchemaRegistryClient. url ^int max-capacity))
+  ([^String url max-capacity config]
+   {:pre [(string? url)
+          (pos-int? max-capacity)]}
+   (CachedSchemaRegistryClient. url ^int max-capacity config))
+  ([url max-capacity]
+   (client url max-capacity {})))
 
 (defn mock-client
   "Build and return a mock schema registry client.

--- a/src/jackdaw/serdes/resolver.clj
+++ b/src/jackdaw/serdes/resolver.clj
@@ -40,6 +40,7 @@
 
   Options:
   schema-registry-url - The URL for the schema registry
+  schema-registry-config - A map containing additional schema registry client configuration
   type-registry - A mapping per jackdaw.serdes.avro/+base-schema-type-registry+>
   read-only - Specifies that you will not be using the resulting serializer,
               and does not require a schema or schema-filename
@@ -48,7 +49,8 @@
   only the schema registry URL is required."
 
   [& options]
-  (let [{:keys [type-registry schema-registry-url schema-registry-client]}
+  (let [{:keys [type-registry schema-registry-url
+                schema-registry-client schema-registry-config]}
         (apply hash-map options)]
 
     (fn [{:keys [serde-keyword schema schema-filename key? read-only?] :as serde-config}]
@@ -67,5 +69,6 @@
                             (s/explain-data :jackdaw.serde/confluent-avro-serde serde-config)))
             (serde-fn schema-registry-url schema key? {:type-registry type-registry
                                                        :schema-registry-client schema-registry-client
+                                                       :schema-registry-config schema-registry-config
                                                        :read-only? read-only?}))
           (serde-fn))))))


### PR DESCRIPTION
Currently our schema registry client receives as a parameter only `schema.registry.url` which makes it impossible to connect to schema registry with enabled basic auth.

This PR adds support for additional configuration map that for example may contain auth parameters:
```
(def basic-auth-config {"basic.auth.credentials.source" "USER_INFO"
                        "basic.auth.user.info"          "fred:letmein"}
```

The map can be passed in various places:
- in `jackdaw.serdes.avro.schema-registry/client`

   ```
   (client "http://localhost:8081" 10 basic-auth-config)
   ```
- in `jackdaw.serdes.resolver/serde-resolver`

   ```
   (serde-resolver :schema-registry-url "http://localhost:8081" :schema-registry-config basic-auth-config)
   ```
- in `jackdaw.serdes.avro.confluent/serde`

   ```
   (serde "http://localhost:8081" schema key? {:schema-registry-config basic-auth-config})
   ```
- in `jackdaw.serdes.avro/serde`

   ```
   (serde {:avro.schema-registry/url "http://localhost:8081"
           :avro.schema-registry/config basic-auth-config} 
          topic-config)
   ```

# Checklist

- [ ] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
