### PR TITLE
Enable naming global-ktable local store

### DIFF
--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -38,8 +38,11 @@
 (defn global-ktable
   "Creates a GlobalKTable that will consist of data from the specified
   topic."
-  [streams-builder topic-config]
-  (p/global-ktable streams-builder topic-config))
+  ([streams-builder topic-config]
+   (p/global-ktable streams-builder topic-config))
+  ([streams-builder topic-config store-name]
+   (p/global-ktable streams-builder topic-config store-name)))
+
 
 (defn source-topics
   "Gets the names of source topics for the topology."

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -92,6 +92,17 @@
               ^Consumed (topic->consumed topic-config)
               ^Materialized (topic->materialized (assoc topic-config
                                                         :topic-name store-name)))))))
+(def ^:private global-ktable-memo
+  "Returns a global-ktable for the topic, creating a new one if needed."
+  (memoize
+   (fn [streams-builder {:keys [topic-name] :as topic-config}
+        store-name]
+     (clj-global-ktable
+      (.globalTable ^StreamsBuilder streams-builder
+                    ^String topic-name
+                    ^Consumed (topic->consumed topic-config)
+                    ^Materialized (topic->materialized (assoc topic-config
+                                                              :topic-name store-name)))))))
 
 (deftype CljStreamsBuilder [^StreamsBuilder streams-builder]
   IStreamsBuilder
@@ -121,11 +132,13 @@
     [_ topic-config store-name]
     (ktable-memo streams-builder topic-config store-name))
 
-  (global-ktable [_ {:keys [topic-name] :as topic-config}]
-    (clj-global-ktable
-     (.globalTable ^StreamsBuilder streams-builder
-                   ^String topic-name
-                   ^Consumed (topic->consumed topic-config))))
+  (global-ktable 
+    [_ {:keys [topic-name] :as topic-config}]
+    (global-ktable-memo streams-builder topic-config topic-name))
+  
+  (global-ktable 
+    [_ {:keys [topic-name] :as topic-config} store-name]
+    (global-ktable-memo streams-builder topic-config store-name))
 
   (streams-builder*
     [_]

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -24,8 +24,9 @@
 
   (global-ktable
     [topology-builder topic-config]
+    [topology-builder topic-config store-name]
     "Creates a GlobalKTable that will consist of data from the specified
-    topic.")
+     topic.")
 
   (source-topics
     [topology-builder]


### PR DESCRIPTION
The current implementation doesn't support naming the GlobalKTable store.  This pull request adds functionality by extending the protocol IStreamsBuilder and adding a new arity to the existing global-ktable function. Implementation follows the same pattern used to name ktable local stores.
