### PR TITLE
bump netty related packages to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Bump netty related packages to latest version (related to changes in `0.7.8` which fixes CVEs).
+
 ## [0.7.8] - [2021-03-01]
 * Override the netty version pulled by Aleph with one which fixes https://nvd.nist.gov/vuln/detail/CVE-2020-11612 [#261](https://github.com/FundingCircle/jackdaw/pull/261)
 * Restore the test fixture namespace [#266](https://github.com/FundingCircle/jackdaw/pull/266)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+## [0.7.9] - [2021-04-13]
 * Bump netty related packages to latest version (related to changes in `0.7.8` which fixes CVEs).
 
 ## [0.7.8] - [2021-03-01]

--- a/project.clj
+++ b/project.clj
@@ -30,14 +30,14 @@
 
                  ;; Pull specific netty version to avoid critical CVE
                  ;; pulled by Aleph v0.4.6 (last stable version)
-                 [io.netty/netty-transport "4.1.59.Final"]
-                 [io.netty/netty-transport-native-epoll "4.1.59.Final"]
-                 [io.netty/netty-codec "4.1.59.Final"]
-                 [io.netty/netty-codec-http "4.1.59.Final"]
-                 [io.netty/netty-handler "4.1.59.Final"]
-                 [io.netty/netty-handler-proxy "4.1.59.Final"]
-                 [io.netty/netty-resolver "4.1.59.Final"]
-                 [io.netty/netty-resolver-dns "4.1.59.Final"]
+                 [io.netty/netty-transport "4.1.63.Final"]
+                 [io.netty/netty-transport-native-epoll "4.1.63.Final"]
+                 [io.netty/netty-codec "4.1.63.Final"]
+                 [io.netty/netty-codec-http "4.1.63.Final"]
+                 [io.netty/netty-handler "4.1.63.Final"]
+                 [io.netty/netty-handler-proxy "4.1.63.Final"]
+                 [io.netty/netty-resolver "4.1.63.Final"]
+                 [io.netty/netty-resolver-dns "4.1.63.Final"]
                  ]
 
   :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}


### PR DESCRIPTION
# Description
Bump netty related packages from `4.1.59.Final` to `4.1.63.Final`

# Checklist
- [x] bump netty.
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
