### PR TITLE
Fix docs

### DIFF
--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -32,7 +32,7 @@ to these services in a shared environment like uat/staging.
   (:require
     [my.app :as app]
     [jackdaw.serdes :refer [string-serde edn-serde]]
-    [jackdaw.serdes.json :as json-serde]
+    [jackdaw.serdes.json :as jsj]
     [jackdaw.test :refer [test-machine]]
     [jackdaw.test.transports :as trns]))
 
@@ -47,7 +47,7 @@ to these services in a shared environment like uat/staging.
 (def topic-config
   {:foo {:topic-name "foo"
          :key-serde (string-serde)
-         :value-serde (json-serde/serde)
+         :value-serde (jsj/serde)
          :partition-count 1
          :replication-factor 1}
    :bar {:topic-name "foo"

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -40,6 +40,10 @@ to these services in a shared environment like uat/staging.
   {"bootstrap.servers" "localhost:9092"
    "group.id" "my-app"})
 
+(def remote-kafka-config
+  {:bootstrap-uri "my-real-rest-proxy-url"
+   :group-id "my-app"})
+
 (def topic-config
   {:foo {:topic-name "foo"
          :key-serde (string-serde)

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -31,7 +31,7 @@ to these services in a shared environment like uat/staging.
 (ns my.app-test
   (:require
     [my.app :as app]
-    [jackdaw.test :as j.t]
+    [jackdaw.test :refer [test-machine]]
     [jackdaw.test.transports :as trns]))
 
 (def local-kafka-config
@@ -50,13 +50,13 @@ to these services in a shared environment like uat/staging.
   (let [t (trns/transport {:type :kafka
                            :config local-kafka-config
                            :topics topic-config})]
-    (j.t/test-machine {:transport t})))
+    (test-machine {:transport t})))
 
 (def remote-machine []
   (let [t (trns/transport {:type :confluent-rest-proxy
                            :config remote-kafka-config
                            :topics topic-config})]
-   (j.t/test-machine t)))
+   (test-machine t)))
 ```
 
 ### Serialization/Deserialization
@@ -135,6 +135,13 @@ better that you write this macro yourself so that you can tailor it to your own
 requirements.
 
 ```clojure
+(ns my.app-test
+  (:require
+    [my.app :as app]
+    [jackdaw.test :refer [test-machine]]
+    [jackdaw.test.fixtures :as fix]
+    [jackdaw.test.transports :as trns]))
+
 (defn with-test-machine [f {:keys [transport}]}]
   (fix/with-fixtures [(fix/topic-fixture kafka-config input-topics)
                       (fix/topic-fixture kafka-config output-topics)

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -64,7 +64,7 @@ to these services in a shared environment like uat/staging.
                            :topics topic-config})]
     (test-machine t)))
 
-(def remote-machine []
+(defn remote-machine []
   (let [t (trns/transport {:type :confluent-rest-proxy
                            :config remote-kafka-config
                            :topics topic-config})]
@@ -184,5 +184,4 @@ requirements.
       (f machine))))
 ```
 
-The `topic-fixture` creates all the topics named in the supplied `topic-config` before running tests.
-Note that you have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version within `2.0.0` to `2.3.0`. Also note that the `topic-fixture` expects the `topic-config` to contain `:partition-count` and :replication-factor` to be present, as well as the `topic-name` and key-value serdes.
+The `topic-fixture` function creates all the topics named in the supplied `topic-config` before running tests. You have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version within `2.0.0` - `2.3.0`. The `topic-fixture` expects the `topic-config` to contain `:partition-count` and :replication-factor` to be present, besides the `topic-name` and key-value serdes.

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -116,6 +116,7 @@ specific arguments. Currently the following commands are the supported.
                                  function of a single argument. This function will
                                  be passed the entire test machine state.
 ```
+For more details see the functions in the [jackdaw.test.commands](https://cljdoc.org/d/fundingcircle/jackdaw/CURRENT/api/jackdaw.test.commands) namespace.
 
 ### Test Results
 
@@ -183,4 +184,5 @@ requirements.
       (f machine))))
 ```
 
-Note that you have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version from `2.0.0` to `2.3.0`. Also note that the `topic-fixture` expects the `topic-config` to contain `:partition-count` and :replication-factor` to be present, as well as the `topic-name` and key-value serdes.
+The `topic-fixture` creates all the topics named in the supplied `topic-config` before running tests.
+Note that you have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version within `2.0.0` to `2.3.0`. Also note that the `topic-fixture` expects the `topic-config` to contain `:partition-count` and :replication-factor` to be present, as well as the `topic-name` and key-value serdes.

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -124,7 +124,7 @@ in the order that they were observed.
 
 A selection of fixtures are provided to help setting up required topics and
 to start the applications, and external systems under test. For more details
-see the functions in the jackdaw.test.fixtures namespace.
+see the functions in the [jackdaw.test.fixtures](https://cljdoc.org/d/fundingcircle/jackdaw/CURRENT/api/jackdaw.test.fixtures) namespace.
 
 ### Wrapping up
 

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -47,10 +47,12 @@ to these services in a shared environment like uat/staging.
 (def topic-config
   {:foo {:topic-name "foo"
          :key-serde (string-serde)
-         :value-serde (json-serde/serde)}
+         :value-serde (json-serde/serde)
+         :partition-count 1}
    :bar {:topic-name "foo"
          :key-serde (string-serde)
-         :value-serde (edn-serde)}})
+         :value-serde (edn-serde)
+         :partition-count 1}})
 
 (defn local-machine []
   (let [t (trns/transport {:type :kafka

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -31,6 +31,8 @@ to these services in a shared environment like uat/staging.
 (ns my.app-test
   (:require
     [my.app :as app]
+    [jackdaw.serdes :refer [string-serde edn-serde]]
+    [jackdaw.serdes.json :as json-serde]
     [jackdaw.test :refer [test-machine]]
     [jackdaw.test.transports :as trns]))
 
@@ -41,7 +43,7 @@ to these services in a shared environment like uat/staging.
 (def topic-config
   {:foo {:topic-name "foo"
          :key-serde (string-serde)
-         :value-serde (json-serde)}
+         :value-serde (json-serde/serde)}
    :bar {:topic-name "foo"
          :key-serde (string-serde)
          :value-serde (edn-serde)}})

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -35,8 +35,6 @@ to these services in a shared environment like uat/staging.
     [jackdaw.serdes.json :as json-serde]
     [jackdaw.test :refer [test-machine]]
     [jackdaw.test.transports :as trns]))
-  (:import
-    (org.apache.kafka.streams TopologyTestDriver))
 
 (def local-kafka-config
   {"bootstrap.servers" "localhost:9092"
@@ -93,6 +91,7 @@ conjunction with `with-open` to ensure that associated resources are shut down
 cleanly when you are finished with a machine.
 
 ### Test Commands
+
 Each test-command is a vector with the first item being a keyword representing the
 type of operation this command represents, and subsequent items being command
 specific arguments. Currently the following commands are the supported.

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -56,7 +56,7 @@ to these services in a shared environment like uat/staging.
   (let [t (trns/transport {:type :kafka
                            :config local-kafka-config
                            :topics topic-config})]
-    (test-machine {:transport t})))
+    (test-machine t)))
 
 (def remote-machine []
   (let [t (trns/transport {:type :confluent-rest-proxy
@@ -113,7 +113,7 @@ specific arguments. Currently the following commands are the supported.
 
 ### Test Results
 
-A `test-machine` is used in conjunction with `run-test`, which runs a sequence of test commands against a test-machine. The first parameter to `run-test` is a test-machine and the second is a list of commands to execute. The return value from `run-test` is a map with just two keys
+A `test-machine` is used in conjunction with `run-test`, which runs a sequence of test commands against the test-machine. The first parameter to `run-test` is a test-machine and the second is a list of commands to execute. The return value from `run-test` is a map with just two keys
 
 ```clojure
 :results   A sequence of execution results. One for each command attempted
@@ -144,8 +144,7 @@ requirements.
   (:require
     [my.app :as app]
     [jackdaw.test :refer [test-machine]]
-    [jackdaw.test.fixtures :as fix]
-    [jackdaw.test.transports :as trns]))
+    [jackdaw.test.fixtures :as fix]))
 
 (defn with-test-machine [f {:keys [transport}]}]
   (fix/with-fixtures [(fix/topic-fixture kafka-config input-topics)

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -87,7 +87,6 @@ conjunction with `with-open` to ensure that associated resources are shut down
 cleanly when you are finished with a machine.
 
 ### Test Commands
-
 Each test-command is a vector with the first item being a keyword representing the
 type of operation this command represents, and subsequent items being command
 specific arguments. Currently the following commands are the supported.
@@ -114,7 +113,7 @@ specific arguments. Currently the following commands are the supported.
 
 ### Test Results
 
-The return value from `run-test` is a map with just two keys
+A `test-machine` is used in conjunction with `run-test`, which runs a sequence of test commands against a test-machine. The first parameter to `run-test` is a test-machine and the second is a list of commands to execute. The return value from `run-test` is a map with just two keys
 
 ```clojure
 :results   A sequence of execution results. One for each command attempted

--- a/doc/test-machine.md
+++ b/doc/test-machine.md
@@ -185,4 +185,4 @@ requirements.
       (f machine))))
 ```
 
-The `topic-fixture` function creates all the topics named in the supplied `topic-config` before running tests. You have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version within `2.0.0` - `2.3.0`. The `topic-fixture` expects the `topic-config` to contain `:partition-count` and :replication-factor` to be present, besides the `topic-name` and key-value serdes.
+The `topic-fixture` function creates all the topics named in the supplied `topic-config` before running tests. You have to import `TopologyTestDriver` for `test-machine` to work, which requires you to bring in the `org.apache.kafka/kafka-streams-test-utils` library as a dependency, using a version within `2.0.0` - `2.3.0`. The `topic-fixture` expects the `topic-config` to contain `:partition-count` and `:replication-factor` to be present, besides the `topic-name` and key-value serdes.


### PR DESCRIPTION
# Summary of changes
Fixes the code examples and documentation for `test-machine`

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)