### PR TITLE
Fix the pipe example project

### DIFF
--- a/examples/pipe/README.md
+++ b/examples/pipe/README.md
@@ -43,15 +43,13 @@ The `pipe_test.clj` file contains a test.
 
 ## Running the app
 
-Let's get started! Fire up a Clojure REPL and load the `pipe` namespace. Then, start ZooKeeper and Kafka. If these services are already running, you may skip this step:
+Let's get started! Fire up a Clojure REPL, then, start ZooKeeper and Kafka. 
+You can use the helper `docker-compose.yml` file provided with this project, i.e. run
 ```
-user> (confluent/start)
-INFO zookeeper is up (confluent:288)
-INFO kafka is up (confluent:288)
-nil
+docker-compose up -d
 ```
 
-Now, start the app.
+Now, start the app, i.e. in the REPL run:
 ```
 user> (start)
 INFO topic 'input' is created (jackdaw.admin.client:288)
@@ -60,26 +58,31 @@ INFO pipe is up (pipe:288)
 {:app #object[org.apache.kafka.streams.KafkaStreams 0x225dcbb9 "org.apache.kafka.streams.KafkaStreams@225dcbb9"]}
 ```
 
-The `user/start` function creates two Kafka topics needed by Pipe and starts it.
+The `start` function creates two Kafka topics needed by Pipe and starts it.
 
 For the full list of topics, type:
 ```
-user> (get-topics)
+user> (list-topics)
 #{"output" "__confluent.support.metrics" "input"}
 ```
 
 With the app running, place a new record on the input stream:
 ```
-user> (publish (topic-config "input") nil "this is a pipe")
-INFO {:key nil, :value "this is a pipe"} (pipe:288)
-nil
+user> (publish {:k1 "Some value" :k2 "Some other value"})
+{:topic-name "input",
+ :partition 0,
+ :timestamp 1620320890747,
+ :offset 0,
+ :serialized-key-size -1,
+ :serialized-value-size 42}
 ```
+
 Pipe logs the key and value to the standard output.
 
 To read from the output stream:
 ```
-user> (get-keyvals (topic-config "output"))
-((nil "this is a pipe"))
+user> (consume)
+({:k1 "Some value", :k2 "Some other value"})
 ```
 
 This concludes this tutorial.

--- a/examples/pipe/dev/user.clj
+++ b/examples/pipe/dev/user.clj
@@ -1,0 +1,22 @@
+(ns user
+  (:require [system :refer :all]))
+
+
+(comment
+  ;;; Evaluate the forms.
+  ;;;
+
+  ;; Start ZooKeeper and Kafka, e.g. by running
+  ;; `docker-compose up -d` from this example project's root folder.
+
+  ;; Create the `input` and `output` topics, and start the app.
+  (start)
+
+  ;; Get a list of current topics.
+  (list-topics)
+
+  ;; Write to the input stream.
+  (publish {:k1 "Some value" :k2 "Some other value"})
+
+  ;; Read from the output stream.
+  (consume))

--- a/examples/pipe/docker-compose.yml
+++ b/examples/pipe/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  kafka:
+    image: confluentinc/cp-kafka:6.1.1
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_NUM_PARTITIONS: 12
+    ports:
+      - "9092:9092"
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.1.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+    ports:
+      - "2181:2181"

--- a/examples/pipe/src/pipe.clj
+++ b/examples/pipe/src/pipe.clj
@@ -5,29 +5,24 @@
   Pipe reads from a Kafka topic called `input`, logs the key and
   value, and writes these to a Kafka topic called `output`."
   (:gen-class)
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :refer [info]]
-            [jackdaw.streams :as j]
-            [jackdaw.serdes.edn :as jse])
-  (:import [org.apache.kafka.common.serialization Serdes]))
+  (:require [jackdaw.serdes.edn :as jse]
+            [jackdaw.streams :as j]))
 
 
 (defn topic-config
   "Takes a topic name and returns a topic configuration map, which may
   be used to create a topic or produce/consume records."
   [topic-name]
-  {:topic-name topic-name
-   :partition-count 1
+  {:topic-name         topic-name
+   :partition-count    1
    :replication-factor 1
-   :key-serde (jse/serde)
-   :value-serde (jse/serde)})
+   :key-serde          (jse/serde)
+   :value-serde        (jse/serde)})
 
 
-(defn app-config
-  "Returns the application config."
-  []
-  {"application.id" "pipe"
-   "bootstrap.servers" "localhost:9092"
+(def app-config
+  {"application.id"            "pipe"
+   "bootstrap.servers"         "localhost:9092"
    "cache.max.bytes.buffering" "0"})
 
 (defn build-topology
@@ -36,60 +31,28 @@
   topology builder."
   [builder]
   (-> (j/kstream builder (topic-config "input"))
-      (j/peek (fn [[k v]]
-                (info (str {:key k :value v}))))
+      (j/peek (fn [[k v]] (println (str {:key k :value v}))))
       (j/to (topic-config "output")))
   builder)
 
 (defn start-app
   "Starts the stream processing application."
-  [app-config]
-  (let [builder (j/streams-builder)
-        topology (build-topology builder)
-        app (j/kafka-streams topology app-config)]
-    (j/start app)
-    (info "pipe is up")
-    app))
+  ([] (start-app app-config))
+  ([app-config]
+   (let [builder (j/streams-builder)
+         topology (build-topology builder)
+         app (j/kafka-streams topology app-config)]
+     (j/start app)
+     (println "pipe is up")
+     app)))
 
 (defn stop-app
   "Stops the stream processing application."
   [app]
   (j/close app)
-  (info "pipe is down"))
+  (println "pipe is down"))
 
 
 (defn -main
   [& _]
-  (start-app (app-config)))
-
-
-(comment
-  ;;; Evaluate the forms.
-  ;;;
-
-  ;; Needed to invoke the forms from this namespace. When typing
-  ;; directly in the REPL, skip this step.
-  (require '[user :refer :all :exclude [topic-config]])
-
-
-  ;; Start ZooKeeper and Kafka.
-  ;; This requires the Confluent Platform CLI which may be obtained
-  ;; from `https://www.confluent.io/download/`. If ZooKeeper and Kafka
-  ;; are already running, skip this step.
-  (confluent/start)
-
-
-  ;; Create the `input` and `output` topics, and start the app.
-  (start)
-
-
-  ;; Get a list of current topics.
-  (list-topics)
-
-
-  ;; Write to the input stream.
-  (publish (topic-config "input") nil "this is a pipe")
-
-
-  ;; Read from the output stream.
-  (get-keyvals (topic-config "output")))
+  (start-app app-config))


### PR DESCRIPTION
I had some trouble running the `pipe` sample code, so I updated it and, hopefully, made it better. This PR is pure documentation update.

Changes:
 - Add docker-compose to facilitate starting a local kafka.
 - Add utility functions for producing and consuming Kafka messages.
 - Fix the system start and stop.
 - Move the sample calls in a `(comment)` in the `user` ns.
 - Update the README.md file

# Checklist

- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
