### PR TITLE
Some additions and helpers for Kafka Streams interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## Unreleased
-* Drop clj-time dependency
-* Added confluent schema registry support for JSON Schema
-* Removed dependency on deprecated `org.apache.kafka.streams.kstream.Serialized` class
+* Drop clj-time dependency.
+* Added confluent schema registry support for JSON Schema.
+* Removed dependency on deprecated `org.apache.kafka.streams.kstream.Serialized` class.
+* Added simple helpers in lambdas for using transformers more easily in a stream. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
+* Added the `flatTransform` and `flatTransfromValues` calls to the core streams interface. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
+* Aded a helper function to add KV state stores to a streams builder. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
 
 ### Added
 

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -206,34 +206,6 @@
   ([kstream transformer-supplier-fn state-store-names]
    (p/transform kstream transformer-supplier-fn state-store-names)))
 
-(defn transform-values
-  "Creates a KStream that consists of the results of applying the transformer
-  to each value in the input stream."
-  ([kstream value-transformer-supplier-fn]
-   (p/transform-values kstream value-transformer-supplier-fn))
-  ([kstream value-transformer-supplier-fn state-store-names]
-   (p/transform-values kstream value-transformer-supplier-fn state-store-names)))
-
-(defn join-global
-  [kstream global-ktable kv-mapper joiner]
-  (p/join-global kstream global-ktable kv-mapper joiner))
-
-(defn left-join-global
-  [kstream global-ktable kv-mapper joiner]
-  (p/left-join-global kstream global-ktable kv-mapper joiner))
-
-(defn merge
-  [kstream other]
-  (p/merge kstream other))
-
-(defn transform
-  "Creates a KStream that consists of the results of applying the transformer
-  to each key/value in the input stream."
-  ([kstream transformer-supplier-fn]
-   (p/transform kstream transformer-supplier-fn))
-  ([kstream transformer-supplier-fn state-store-names]
-   (p/transform kstream transformer-supplier-fn state-store-names)))
-
 (defn flat-transform
   "Creates a KStream that consists of the results of applying the transformer
   to each value in the input stream. Result of the transform should be iterable,
@@ -259,6 +231,18 @@
    (p/flat-transform-values kstream value-transformer-supplier-fn))
   ([kstream value-transformer-supplier-fn state-store-names]
    (p/flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
+
+(defn join-global
+  [kstream global-ktable kv-mapper joiner]
+  (p/join-global kstream global-ktable kv-mapper joiner))
+
+(defn left-join-global
+  [kstream global-ktable kv-mapper joiner]
+  (p/left-join-global kstream global-ktable kv-mapper joiner))
+
+(defn merge
+  [kstream other]
+  (p/merge kstream other))
 
 (defn kstream*
   "Returns the underlying KStream object."

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -46,6 +46,12 @@
   [streams-builder]
   (p/source-topics streams-builder))
 
+(defn with-kv-state-store
+  "Adds a persistent state store to the topology with the configured name
+  and serdes"
+  [streams-builder store-config]
+  (p/with-kv-state-store streams-builder store-config))
+
 (defn streams-builder*
   "Returns the underlying KStreamBuilder."
   [streams-builder]
@@ -219,6 +225,40 @@
 (defn merge
   [kstream other]
   (p/merge kstream other))
+
+(defn transform
+  "Creates a KStream that consists of the results of applying the transformer
+  to each key/value in the input stream."
+  ([kstream transformer-supplier-fn]
+   (p/transform kstream transformer-supplier-fn))
+  ([kstream transformer-supplier-fn state-store-names]
+   (p/transform kstream transformer-supplier-fn state-store-names)))
+
+(defn flat-transform
+  "Creates a KStream that consists of the results of applying the transformer
+  to each value in the input stream. Result of the transform should be iterable,
+  and the resulting stream is as per flatMap"
+  ([kstream transformer-supplier-fn]
+   (p/flat-transform kstream transformer-supplier-fn))
+  ([kstream transformer-supplier-fn state-store-names]
+   (p/flat-transform kstream transformer-supplier-fn state-store-names)))
+
+(defn transform-values
+  "Creates a KStream that consists of the results of applying the transformer
+  to each value in the input stream."
+  ([kstream value-transformer-supplier-fn]
+   (p/transform-values kstream value-transformer-supplier-fn))
+  ([kstream value-transformer-supplier-fn state-store-names]
+   (p/transform-values kstream value-transformer-supplier-fn state-store-names)))
+
+(defn flat-transform-values
+  "Creates a KStream that consists of the results of applying the transformer
+  to each value in the input stream. Result of the transform should be iterable,
+  and the resulting stream is as per flatMap"
+  ([kstream value-transformer-supplier-fn]
+   (p/flat-transform-values kstream value-transformer-supplier-fn))
+  ([kstream value-transformer-supplier-fn state-store-names]
+   (p/flat-transform-values kstream value-transformer-supplier-fn state-store-names)))
 
 (defn kstream*
   "Returns the underlying KStream object."

--- a/src/jackdaw/streams/lambdas.clj
+++ b/src/jackdaw/streams/lambdas.clj
@@ -187,8 +187,8 @@
 
 (deftype FnTransformer [context xfm-fn]
   Transformer
-  (init [this trasnformer-context]
-    (reset! context trasnformer-context))
+  (init [this transformer-context]
+    (reset! context transformer-context))
   (close [this])
   (transform [this k v]
     (xfm-fn @context k v)))
@@ -211,8 +211,8 @@
 
 (deftype FnValueTransformer [context xfm-fn]
   ValueTransformer
-  (init [this trasnformer-context]
-    (reset! context trasnformer-context))
+  (init [this transformer-context]
+    (reset! context transformer-context))
   (close [this])
   (transform [this v]
     (xfm-fn @context v)))

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -2,14 +2,13 @@
   "Mocks for testing kafka streams."
   {:license "BSD 3-Clause License <https://github.com/FundingCircle/jackdaw/blob/master/LICENSE>"}
   (:refer-clojure :exclude [send])
-  (:require [jackdaw.streams.protocols :as k]
-            [jackdaw.streams.configurable :refer [config configure]]
-            [jackdaw.streams.configured :as configured]
+  (:require [jackdaw.streams :as js]
             [jackdaw.streams.interop :as interop]
+            [jackdaw.streams.protocols :as k]
             [jackdaw.data :as data])
   (:import java.nio.file.Files
            java.nio.file.attribute.FileAttribute
-           org.apache.kafka.streams.TopologyTestDriver
+           [org.apache.kafka.streams Topology TopologyTestDriver]
            java.util.Properties
            org.apache.kafka.streams.test.ConsumerRecordFactory
            org.apache.kafka.common.header.internals.RecordHeaders
@@ -17,49 +16,22 @@
 
 (set! *warn-on-reflection* false)
 
-(defn streams-builder
-  "Creates a mock streams-builder."
-  ([]
-   (streams-builder (interop/streams-builder)))
-  ([streams-builder]
-   (configured/streams-builder
-    {::streams-builder (k/streams-builder* streams-builder)}
-    streams-builder)))
+(defn topology->test-driver
+  ""
+  [topology]
+  (TopologyTestDriver.
+    topology
+    (doto (Properties.)
+      (.put "application.id"      (str (java.util.UUID/randomUUID)))
+      (.put "bootstrap.servers"   "fake")
+      (.put "default.key.serde"   "jackdaw.serdes.EdnSerde")
+      (.put "default.value.serde" "jackdaw.serdes.EdnSerde"))))
 
 (defn streams-builder->test-driver
   ""
   [streams-builder]
-  (let [topology (-> streams-builder config ::streams-builder .build)]
-    (TopologyTestDriver.
-     topology
-     (doto (Properties.)
-       (.put "application.id"      (str (java.util.UUID/randomUUID)))
-       (.put "bootstrap.servers"   "fake")
-       (.put "default.key.serde"   "jackdaw.serdes.EdnSerde")
-       (.put "default.value.serde" "jackdaw.serdes.EdnSerde")))))
-
-(defn send
-  "Publishes message to a topic."
-  [topology topic-config key message]
-  (let [test-driver (-> topology config ::test-driver)
-        time (or (-> topology config ::test-driver-time) 0)]
-    (.setTime test-driver time)
-    (.process test-driver
-              (:topic-name topic-config)
-              key
-              message)
-    (.flushState test-driver)
-    (-> topology
-        (configure ::test-driver-time (inc time)))))
-
-(defn collect
-  "Collects the test results. The test driver returns a list of messages with
-  each message formatted like \"key:value\""
-  [streams-builder]
-  (let [processor-supplier (-> streams-builder config ::processor-supplier)
-        processed (vec (.processed processor-supplier))]
-    (.clear (.processed processor-supplier))
-    processed))
+  (let [topology (.build (js/streams-builder* streams-builder))]
+    (topology->test-driver topology)))
 
 (defn producer
   ""
@@ -107,9 +79,15 @@
   (repeatedly-consume test-driver topic-config))
 
 (defn build-driver [f]
-  (let [builder (streams-builder)]
+  (let [builder (interop/streams-builder)]
     (f builder)
     (streams-builder->test-driver builder)))
+
+(defn build-topology-driver [f]
+  (let [topology (Topology.)]
+    (f topology)
+    (topology->test-driver topology)))
+
 
 ;; FIXME (arrdem 2018-11-24):
 ;;   This is used by the test suite but has no bearing on anything else

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -17,7 +17,7 @@
 (set! *warn-on-reflection* false)
 
 (defn topology->test-driver
-  ""
+  "Given a kafka streams topology, return a topology test driver for it"
   [topology]
   (TopologyTestDriver.
     topology
@@ -28,13 +28,15 @@
       (.put "default.value.serde" "jackdaw.serdes.EdnSerde"))))
 
 (defn streams-builder->test-driver
-  ""
+  "Given the jackdaw streams builder, return a builds the described topology
+  and returns a topology test driver for that topology"
   [streams-builder]
   (let [topology (.build (js/streams-builder* streams-builder))]
     (topology->test-driver topology)))
 
 (defn producer
-  ""
+  "Returns a function which can be used to pubish data to a topic for the
+  topology test driver"
   [test-driver
    {:keys [topic-name
            ^Serde key-serde

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -31,6 +31,11 @@
     [topology-builder]
     "Gets the names of source topics for the topology.")
 
+  (with-kv-state-store
+    [topology-builder store-config]
+    "Adds a persistent state store to the topology with the configured name
+    and serdes.")
+    
   (streams-builder*
     [streams-builder]
     "Returns the underlying KStreamBuilder."))
@@ -166,11 +171,23 @@
     "Creates a KStream that consists of the results of applying the transformer
     to each key/value in the input stream.")
 
+  (flat-transform
+    [kstream transformer-supplier-fn]
+    [kstream transformer-supplier-fn state-store-names]
+    "Creates a KStream that consists of the results of applying the transformer
+    to each key/value in the input stream via flatTransform.")
+
   (transform-values
     [kstream value-transformer-supplier-fn]
     [kstream value-transformer-supplier-fn state-store-names]
     "Creates a KStream that consists of the results of applying the transformer
     to each value in the input stream.")
+
+  (flat-transform-values
+    [kstream value-transformer-supplier-fn]
+    [kstream value-transformer-supplier-fn state-store-names]
+    "Creates a KStream that consists of the results of applying the transformer
+    to each key/value in the input stream via flatTransformValues.")
 
   (join-global
     [kstream global-ktable kv-mapper joiner])

--- a/src/jackdaw/streams/specs.clj
+++ b/src/jackdaw/streams/specs.clj
@@ -234,7 +234,19 @@
                      :state-store-names (s/? (s/coll-of string?)))
         :ret kstream?)
 
+(s/fdef k/flat-transform
+        :args (s/cat :kstream kstream?
+                     :transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
+        :ret kstream?)
+
 (s/fdef k/transform-values
+        :args (s/cat :kstream kstream?
+                     :value-transformer-supplier-fn ifn?
+                     :state-store-names (s/? (s/coll-of string?)))
+        :ret kstream?)
+
+(s/fdef k/flat-transform-values
         :args (s/cat :kstream kstream?
                      :value-transformer-supplier-fn ifn?
                      :state-store-names (s/? (s/coll-of string?)))

--- a/src/jackdaw/test.clj
+++ b/src/jackdaw/test.clj
@@ -35,7 +35,7 @@
   (:import
    (java.io Closeable)
    (java.util Properties)
-   (org.apache.kafka.streams TopologyTestDriver StreamsBuilder)))
+   (org.apache.kafka.streams Topology TopologyTestDriver StreamsBuilder)))
 
 (set! *warn-on-reflection* true)
 
@@ -247,4 +247,4 @@
                        .build))
         props (-> (Properties.)
                   (set-properties app-config))]
-    (TopologyTestDriver. topology props)))
+    (TopologyTestDriver. ^Topology topology ^Properties props)))

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -1421,7 +1421,7 @@
             (is (= "input-topic" (:topic v)))))))))
 
 (deftest with-kv-state-store-test
-  (testing "Transfromer with state store sugar"
+  (testing "Transformer with state store sugar"
     (let [input-t (mock/topic "input-topic")
           output-t (merge (mock/topic "output-topic") {:value-serde (jse/serde)})]
       (with-open [driver (mock/build-driver


### PR DESCRIPTION
* added simple helpers in `lambdas` for using transformers more easily in a stream
* added the `flatTransform` and `flatTransfromValues` calls to the core streams interface
* added a helper function to add KV state stores to a streams builder