### PR TITLE
Fix CVEs for netty and apache commons-compress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 # Changelog
 
 ## Unreleased
+
+
+### [0.9.1] - [2021-11-19]
+
+* Fixed Circle CI build process.
+
+### [0.9.0] 
+
+This version has been tagged in the repo but unreleased due to the broken build process.
+
 * Drop clj-time dependency.
 * Added confluent schema registry support for JSON Schema.
 * Removed dependency on deprecated `org.apache.kafka.streams.kstream.Serialized` class.
 * Added simple helpers in lambdas for using transformers more easily in a stream. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
 * Added the `flatTransform` and `flatTransfromValues` calls to the core streams interface. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
 * Aded a helper function to add KV state stores to a streams builder. [#305](https://github.com/FundingCircle/jackdaw/pull/305)
-
-### Added
-
 * Add KStream-KTable inner join.
 
 ## [0.8.0] - [2021-05-13]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+### [0.9.2] - [2021-11-23]
+
+* Fixed CVE-2021-37137, CVE-2021-37136 and CVE-2021-36090
+
 ### [0.9.1] - [2021-11-19]
 
 * Fixed Circle CI build process.

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,19 @@
 
   :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]]
 
+  :managed-dependencies [;; Pull specific netty version to avoid critical CVE
+                         ;; pulled by Aleph v0.4.6 (last stable version)
+                         [io.netty/netty-transport "4.1.68.Final"]
+                         [io.netty/netty-transport-native-epoll "4.1.68.Final"]
+                         [io.netty/netty-codec "4.1.68.Final"]
+                         [io.netty/netty-codec-http "4.1.68.Final"]
+                         [io.netty/netty-handler "4.1.68.Final"]
+                         [io.netty/netty-handler-proxy "4.1.68.Final"]
+                         [io.netty/netty-resolver "4.1.68.Final"]
+                         [io.netty/netty-resolver-dns "4.1.68.Final"]
+                         ;; avro 1.9.2 pulls commons-compress 1.19 which suffers CVE-2021-36090
+                         [org.apache.commons/commons-compress "1.21"]
+                         ]
   :dependencies [[aleph "0.4.6"]
                  [danlentz/clj-uuid "0.1.9"
                   :exclusions [primitive-math]]
@@ -27,18 +40,7 @@
                  [org.clojure/data.fressian "0.2.1"]
                  [org.clojure/tools.logging "0.4.1"]
                  [org.clojure/core.cache "0.7.2"]
-                 [metosin/jsonista "0.3.3"]
-
-                 ;; Pull specific netty version to avoid critical CVE
-                 ;; pulled by Aleph v0.4.6 (last stable version)
-                 [io.netty/netty-transport "4.1.63.Final"]
-                 [io.netty/netty-transport-native-epoll "4.1.63.Final"]
-                 [io.netty/netty-codec "4.1.63.Final"]
-                 [io.netty/netty-codec-http "4.1.63.Final"]
-                 [io.netty/netty-handler "4.1.63.Final"]
-                 [io.netty/netty-handler-proxy "4.1.63.Final"]
-                 [io.netty/netty-resolver "4.1.63.Final"]
-                 [io.netty/netty-resolver-dns "4.1.63.Final"]]
+                 [metosin/jsonista "0.3.3"]]
 
   :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.edn2 jackdaw.serdes.fressian jackdaw.serdes.fn-impl]


### PR DESCRIPTION
Fixes CVE-2021-37137, CVE-2021-37136 and CVE-2021-36090. Moving overrides in dependency management as it keeps the structure of the dependency tree as is instead of adding the overriding libs as top level deps.

# Checklist

- [X] tests
- [X] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
