### PR TITLE
Bump due to security issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,8 +33,8 @@
                  ;; pulled by Aleph v0.4.6 (last stable version)
                  [io.netty/netty-transport "4.1.68.Final"]
                  [io.netty/netty-transport-native-epoll "4.1.68.Final"]
-                 [io.netty/netty-codec "4.1.68.Final"]
-                 [io.netty/netty-codec-http "4.1.68.Final"]
+                 [io.netty/netty-codec "4.1.73.Final"]
+                 [io.netty/netty-codec-http "4.1.73.Final"]
                  [io.netty/netty-handler "4.1.68.Final"]
                  [io.netty/netty-handler-proxy "4.1.68.Final"]
                  [io.netty/netty-resolver "4.1.68.Final"]


### PR DESCRIPTION
Bump the following libs due to a security issue
- `io.netty/netty-codec-http` (CVE-2021-37136, CVE-2021-37137)
- `io.netty/netty-codec` (CVE-2021-43797)

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
