### PR TITLE
Add support for TopicNameExtractor in `jackdaw.streams/to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+* Added support for TopicNameExtractor in `jackdaw.streams/to`
 
 ### [0.9.3] - [2021-11-24]
 

--- a/src/jackdaw/streams.clj
+++ b/src/jackdaw/streams.clj
@@ -116,8 +116,10 @@
 
 (defn to
   "Materializes a stream to a topic."
-  [kstream topic-config]
-  (p/to! kstream topic-config))
+  ([kstream topic-config]
+   (p/to! kstream topic-config))
+  ([kstream topic-config topic-name-extractor-fn]
+   (p/to! kstream topic-config topic-name-extractor-fn)))
 
 ;; IKStream
 

--- a/src/jackdaw/streams/interop.clj
+++ b/src/jackdaw/streams/interop.clj
@@ -24,6 +24,7 @@
             Suppressed Suppressed$BufferConfig TimeWindowedKStream ValueJoiner
             ValueMapper ValueMapperWithKey ValueTransformerSupplier Windows]
            [org.apache.kafka.streams.processor
+            TopicNameExtractor
             StreamPartitioner]
            [org.apache.kafka.streams.state
             KeyValueStore Stores]
@@ -237,6 +238,11 @@
   (to!
     [_ {:keys [topic-name] :as topic-config}]
     (.to kstream ^String topic-name ^Produced (topic->produced topic-config))
+    nil)
+
+  (to!
+    [_ topic-config topic-name-extractor-fn]
+    (.to kstream ^TopicNameExtractor (topic-name-extractor topic-name-extractor-fn) ^Produced (topic->produced topic-config))
     nil)
 
   (flat-map-values

--- a/src/jackdaw/streams/lambdas.clj
+++ b/src/jackdaw/streams/lambdas.clj
@@ -7,7 +7,7 @@
             Merger Predicate Reducer Transformer TransformerSupplier
             ValueJoiner ValueMapper ValueTransformer ValueTransformerSupplier]
            [org.apache.kafka.streams.processor
-            Processor ProcessorSupplier StreamPartitioner]))
+            Processor ProcessorSupplier StreamPartitioner TopicNameExtractor]))
 
 (set! *warn-on-reflection* true)
 
@@ -110,6 +110,16 @@
   "Packages up a Clojure fn in a kstream reducer."
   ^Reducer [reducer-fn]
   (FnReducer. reducer-fn))
+
+(deftype FnTopicNameExtractor [topic-name-extractor-fn]
+  TopicNameExtractor
+  (extract [this k v record-ctx]
+    (topic-name-extractor-fn k v record-ctx)))
+
+(defn topic-name-extractor
+  "Packages up a Clojure fn in a kstream topic name extractor."
+  [topic-name-extractor-fn]
+  (FnTopicNameExtractor. topic-name-extractor-fn))
 
 (deftype FnValueJoiner [value-joiner-fn]
   ValueJoiner

--- a/src/jackdaw/streams/protocols.clj
+++ b/src/jackdaw/streams/protocols.clj
@@ -117,6 +117,7 @@
 
   (to!
     [kstream topic-config]
+    [kstream topic-config topic-name-extractor-fn]
     "Materializes a stream to a topic.")
 
   (group-by-key


### PR DESCRIPTION
As of Kafka v2.0.0, it's been possible to dynamically select the topic to sink to on a per-message basis, using an interface called TopicNameExtractor. This enables some nice routing use cases. e.g., events marked urgent can go on the "urgent-priority" topic, and low priority events go to the "low-priority" topic, etc.

Confluent has a [blog post](https://www.confluent.io/blog/putting-events-in-their-place-with-dynamic-routing/) from 2019 about this feature. See also [KIP-303](https://cwiki.apache.org/confluence/display/KAFKA/KIP-303%3A+Add+Dynamic+Routing+in+Streams+Sink)

# Checklist

- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
