### PR TITLE
Move away from deprecated class ConsumerRecordFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Move away from deprecated class ConsumerRecordFactory
 
 ### [0.9.4] - [2022-05-23]
 

--- a/src/jackdaw/data/producer.clj
+++ b/src/jackdaw/data/producer.clj
@@ -64,7 +64,7 @@
   {:key (.getKey tr)
    :value (.getValue tr)
    :headers (.headers tr)
-   :timestamp (.getRecordTime r)})
+   :timestamp (.getRecordTime tr)})
 
 ;;; Record metadata
 

--- a/src/jackdaw/data/producer.clj
+++ b/src/jackdaw/data/producer.clj
@@ -6,7 +6,8 @@
 
 (import '[org.apache.kafka.clients.producer
           ProducerRecord RecordMetadata]
-        'org.apache.kafka.common.header.Headers)
+        'org.apache.kafka.common.header.Headers
+        '(org.apache.kafka.streams.test TestRecord))
 
 (set! *warn-on-reflection* true)
 
@@ -48,8 +49,7 @@
            value
            headers
            partition
-           timestamp]
-    :as m}]
+           timestamp]}]
   (->ProducerRecord {:topic-name topic-name} partition timestamp key value headers))
 
 (defn->data ProducerRecord->data [^ProducerRecord pr]
@@ -60,6 +60,11 @@
    :partition (.partition pr)
    :timestamp (.timestamp pr)})
 
+(defn->data TestRecord->data [^TestRecord tr]
+  {:key (.getKey tr)
+   :value (.getValue tr)
+   :headers (.headers tr)
+   :timestamp (.getRecordTime r)})
 
 ;;; Record metadata
 

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -45,7 +45,7 @@
                                             (.serializer value-serde))]
     (fn produce!
       ([k v]
-       (.pipeInput test-input-topic k v))
+       (.pipeInput test-input-topic (TestRecord. k v)))
       ([time-ms k v]
        (let [record (TestRecord. k v (RecordHeaders.) ^Long time-ms)]
          (.pipeRecordList test-input-topic (List/of record)))))))

--- a/src/jackdaw/streams/mock.clj
+++ b/src/jackdaw/streams/mock.clj
@@ -33,16 +33,16 @@
     (topology->test-driver topology)))
 
 (defn producer
-  "Returns a function which can be used to pubish data to a topic for the
+  "Returns a function which can be used to publish data to a topic for the
   topology test driver"
   [test-driver
    {:keys [topic-name
            ^Serde key-serde
            ^Serde value-serde]}]
-  (let [test-input-topic (.createTopic test-driver
-                                       topic-name
-                                       (.serializer key-serde)
-                                       (.serializer value-serde))]
+  (let [test-input-topic (.createInputTopic test-driver
+                                            topic-name
+                                            (.serializer key-serde)
+                                            (.serializer value-serde))]
     (fn produce!
       ([k v]
        (.pipeInput test-input-topic k v))
@@ -64,10 +64,11 @@
   (let [test-output-topic (.createOutputTopic test-driver
                                               topic-name
                                               (.deserializer key-serde)
-                                              (.deserializer value-serde))
-        record (.readRecord test-output-topic)]
-    (when record
-      (data/datafy record))))
+                                              (.deserializer value-serde))]
+    (when (not (.isEmpty test-output-topic))
+      (-> test-output-topic
+          (.readRecord)
+          (data/datafy)))))
 
 (defn repeatedly-consume
   [test-driver topic-config]

--- a/test/jackdaw/streams_test.clj
+++ b/test/jackdaw/streams_test.clj
@@ -240,30 +240,7 @@
         (publish 1 1)
 
         (is (= [[1 1]] (mock/get-keyvals driver topic-b)))
-        (is (= [[1 1]] (mock/get-keyvals driver topic-c)))))
-    (testing "with partition"
-      (let [topic-a (mock/topic "topic-a")
-            topic-b (assoc (mock/topic "topic-b") :partition-fn (fn [topic-name key value partition-count]
-                                                                  (int 10)))
-            topic-c (mock/topic "topic-c")
-            driver (mock/build-driver (fn [builder]
-                                        (-> builder
-                                            (k/kstream topic-a)
-                                            (k/through topic-b)
-                                            (k/to topic-c))))
-            publish (partial mock/publish driver topic-a)]
-
-        (publish 1 1)
-
-
-        (is (= [{:key 1
-                 :value 1
-                 :partition 10}] (map #(select-keys % [:key :value :partition])
-                                       (mock/get-records driver
-                                                         topic-b))))
-
         (is (= [[1 1]] (mock/get-keyvals driver topic-c))))))
-
 
   (testing "to"
     (let [topic-a (mock/topic "topic-a")


### PR DESCRIPTION
This change removes dependency on the obsolete [test classes that have been removed](https://github.com/apache/kafka/pull/10508) in Kafka 3.0, paving the way for an upgrade. See this article for more context about this removal: https://www.confluent.io/en-gb/blog/test-kafka-streams-with-topologytestdriver/

# Checklist

- [X] tests
- [X] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
