### PR TITLE
[TDI-1361] make the avro serialization exception message more verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## Unreleased
 
 
+### [0.9.4] - [2022-05-23]
+
+* More verbose avro serialization exception errors
+
 ### [0.9.3] - [2021-11-24]
 
 * Move libraries overrides back to dependencies.


### PR DESCRIPTION
Avro error messages now include the relevant path and topic.

On type errors:
- the path points to the attribute that caused the error
- we'll also include the data of said attribute

On any other error (e.g missing/unknown):
- the path points to the map the attribute that caused the error belongs

**Error message examples**

Incorrect Union type - `:my-attribute` is an enum and we supply a string:
```
{:message "java.lang.String is not a valid type for union [NULL, ENUM]", :path [:my-attribute], :data "Something", :topic "topic-name-1"}
```

Incorrect type for nested field `:name` of map `:person`:
```
{:message "java.lang.Long is not a valid type for string", :topic "topic-name-1", :path [:person :name], :data 123}

```

Unknown field `:application-id2` in top level:
```
{:message "Field application_id2 not known in topic_name", :topic "topic-name-1", :path []}
```

Unknown nested field `:name2` in `:person` map:
```
{:message "Field name2 not known in topic_name", :topic "topic-name-1", :path [:person], :data {:name "John", :name2 "dasds", :surname "Doe"}, :path [:person]}
```

Missing required field `:message-id` in top level:
```
{:message "Field message_id type:STRING pos:0 not set and has no default value", :topic "topic-name-1", :path []}
```

Missing nested required field `:name` in `:person` map:
```
{:message "Field name type:STRING pos:0 not set and has no default value", :topic "topic-name-1", :path [:person]}

```
