### PR TITLE
MCPG-231 Do not automatically create a client if none is present:

### DIFF
--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -709,8 +709,7 @@
 
   (let [config {:key?            key?
                 :registry-url    url
-                :registry-client (or client
-                                     (registry/client url 128))
+                :registry-client client
                 ;; Provide the old behavior by default, or fall through to the
                 ;; new behavior of getting the right schema when possible.
                 :read-only?      read-only?


### PR DESCRIPTION
- kafka api takes care of creating a client if none is specified
- if we do create a client here then it does not use some passed through
  config (such as security)

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
