### PR TITLE
[#336] use a confluent version that properly supports kafka 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ### Unreleased
+- use version of confluent platform that supports Kafka 2.8.0
 
 ### [0.9.6] - [2022-08-01]
 

--- a/project.clj
+++ b/project.clj
@@ -15,10 +15,10 @@
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.
                  ;; See https://docs.confluent.io/current/release-notes.html
-                 [io.confluent/kafka-schema-registry-client "6.1.1"
+                 [io.confluent/kafka-schema-registry-client "6.2.6"
                   :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [io.confluent/kafka-avro-serializer "6.1.1"]
-                 [io.confluent/kafka-json-schema-serializer "6.1.1"]
+                 [io.confluent/kafka-avro-serializer "6.2.6"]
+                 [io.confluent/kafka-json-schema-serializer "6.2.6"]
                  [org.apache.kafka/kafka-clients "2.8.0"]
                  [org.apache.kafka/kafka-streams "2.8.0"]
                  [org.apache.kafka/kafka-streams-test-utils "2.8.0"]


### PR DESCRIPTION
fixes #336

# Checklist

- [ ] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
