### PR TITLE
Trivial release to fix API publishing in cljdocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+
+### [0.9.7] - [2022-10-17]
+
+- Trivial release to fix API publishing in cljdocs
 - Fix project.edn repo typo
 
 ### [0.9.6] - [2022-08-01]


### PR DESCRIPTION
# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)

This page is currently broken https://cljdoc.org/d/fundingcircle/jackdaw/0.9.6/doc/readme