### PR TITLE
fix reflection warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ pom.xml.asc
 .cpcache
 .nrepl-port
 /examples/*/target
+.clj-kondo/
+.lsp/
+.calva/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- v0.9.10 introduced some reflection warnings. Whilst harmless seeing `.deleteTopics` appear in your logs at app startup is a little unsettling.
+
 ### [0.9.10] - [2023-04-03]
 - Kafka 3.x series compatibility. Specifically 3.3.2 with this release (including native support for Arm macs) (https://github.com/FundingCircle/jackdaw/pull/353,  https://github.com/FundingCircle/jackdaw/pull/355)
 

--- a/src/jackdaw/admin.clj
+++ b/src/jackdaw/admin.clj
@@ -9,7 +9,7 @@
   (:require
    [jackdaw.data :as jd]
    [manifold.deferred :as d])
-  (:import [java.util Properties]
+  (:import [java.util Collection Properties]
            [org.apache.kafka.clients.admin AdminClient
             DescribeTopicsOptions DescribeClusterOptions DescribeConfigsOptions]))
 
@@ -30,13 +30,13 @@
                       @(.all (.alterConfigs ^AdminClient this topics))))
    :create-topics* (fn [this topics]
                     (d/future
-                      @(.all (.createTopics ^AdminClient this topics))))
+                      @(.all (.createTopics ^AdminClient this ^Collection topics))))
    :delete-topics*  (fn [this topics]
                       (d/future
-                        @(.all (.deleteTopics ^AdminClient this topics))))
+                        @(.all (.deleteTopics ^AdminClient this ^Collection topics))))
    :describe-topics* (fn [this topics]
                        (d/future
-                         @(.all (.describeTopics ^AdminClient this topics (DescribeTopicsOptions.)))))
+                         @(.all (.describeTopics ^AdminClient this ^Collection topics (DescribeTopicsOptions.)))))
    :describe-configs* (fn [this configs]
                         (d/future
                           @(.all (.describeConfigs ^AdminClient this configs (DescribeConfigsOptions.)))))
@@ -95,7 +95,7 @@
         false
 
         :else
-        (do (Thread/sleep wait-ms)
+        (do (Thread/sleep ^long wait-ms)
             (recur client topic (dec num-retries) wait-ms))))
 
 (defn create-topics!

--- a/src/jackdaw/test/commands/base.clj
+++ b/src/jackdaw/test/commands/base.clj
@@ -8,7 +8,7 @@
   {:stop (constantly true)
 
    :sleep (fn [_machine [sleep-ms]]
-            (Thread/sleep sleep-ms))
+            (Thread/sleep ^long sleep-ms))
 
    :println (fn [_machine params]
               (println (apply str params)))


### PR DESCRIPTION
v0.9.10 introduced some reflection warnings. Whilst harmless seeing `.deleteTopics` appear in your logs at app startup is a little unsettling.

# Checklist

- [ ] tests
- [ ] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
