### PR TITLE
Fix avro serialization of union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Fixed a bug with avro serialization, where default values within a union type would not be used correctly.
+
 ### [0.9.12] - [2023-12-05]
 - Support for Foreign Key joins [#365](https://github.com/FundingCircle/jackdaw/pull/365) (Issue [#364])
 - add manifold and keep aleph in dev dependencies [#360](https://github.com/FundingCircle/jackdaw/pull/360). Users of test-machine will have to add aleph to the test deps in their app.

--- a/src/jackdaw/serdes/avro.clj
+++ b/src/jackdaw/serdes/avro.clj
@@ -402,7 +402,7 @@
       (and (every? (fn [[field-key [^Schema$Field field field-coercion]]]
                      (let [field-value (get clj-map field-key ::missing)]
                        (if (= field-value ::missing)
-                         (.defaultVal field)
+                         (.hasDefaultValue field)
                          (match-clj? field-coercion field-value))))
                    field->schema+coercion)
            (empty? unknown-fields))))

--- a/test/jackdaw/serdes/avro_test.clj
+++ b/test/jackdaw/serdes/avro_test.clj
@@ -463,6 +463,21 @@
     (is (= {:myunion {:field2 "hello"}}
            (round-trip serde "whatever" {:myunion {:field2 "hello"}})))))
 
+(deftest default-values-are-used-when-coercing-union-record
+  (let [schema {:type   "record",
+                :name   "myrecord",
+                :fields [{:name "myunion",
+                          :type [{:type   :null}
+                                 {:type   "record",
+                                  :name   "recordtype",
+                                  :fields [{:name "foo"
+                                            :type "boolean"
+                                            :default false}]}]}]}
+        serde  (->serde (json/write-str schema))]
+
+    (is (= {:myunion {:foo false}}
+           (round-trip serde "whatever" {:myunion {}})))))
+
 (deftest record-serde-test
   (let [serde (->serde complex-schema-str)
         valid-map {:string-field "hello"


### PR DESCRIPTION
This is a fix for a bug in the avro serde, where serialization is sometimes ignoring default values that appear within a union type. This is only the case when the default value is `false` or `nil`.

The problem is that when `match-clj?` is called for a record type (as it is within `UnionType`'s `clj->avro` method), it checks whether any fields missing from the clojure data have a default value in the avro schema. To do this it calls `.defaultVal`, but if the default value is `nil` or `false` this returns falsey. I've therefore replaced this call with `.hasDefaultValue`. 

# Checklist

- [x] tests
- [x] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
