### PR TITLE
Kafka 3.9

### DIFF
--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -11,35 +11,34 @@ jobs:
       options: --user 1001 # don't run as root
     services:
       kafka:
-        image: confluentinc/cp-kafka:5.1.3
+        image: apache/kafka:3.7.0
         env:
+          CLUSTER_ID: 8L6g2nShT-eMCtK--X46sw
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
           KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
           KAFKA_BROKER_ID: 1
-          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+          KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:29093
           KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+          KAFKA_LISTENERS: CONTROLLER://:29093,PLAINTEXT://:9092
+          KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+          KAFKA_PROCESS_ROLES: broker,controller
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+          KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       schema-registry:
-        image: confluentinc/cp-schema-registry:5.1.2
+        image: confluentinc/cp-schema-registry:7.6.0
         env:
           SCHEMA_REGISTRY_HOST_NAME: schema-registry
-          SCHEMA_REGISTRY_KAFKASTORE_CONNECTION_URL: 'zookeeper:2181'
+          SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
+          SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
       kafka-rest:
-        image: confluentinc/cp-kafka-rest:6.1.1
+        image: confluentinc/cp-kafka-rest:7.6.0
         env:
-          KAFKA_REST_ZOOKEEPER_CONNECT: zookeeper:2181
           KAFKA_REST_BOOTSTRAP_SERVERS: kafka:9092
-          KAFKA_REST_LISTENERS: http://0.0.0.0:8082
-          KAFKA_REST_SCHEMA_REGISTRY: http://schema-registry:8081
           KAFKA_REST_HOST_NAME: kafka-rest
-      zookeeper:
-        image: confluentinc/cp-zookeeper:5.1.3
-        env: 
-          ZOOKEEPER_CLIENT_PORT: 2181
-          ZOOKEEPER_TICK_TIME: 2000
+          KAFKA_REST_LISTENERS: http://0.0.0.0:8082
+          KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -52,7 +51,6 @@ jobs:
           lein kaocha
         env: 
           KAFKA_BOOTSTRAP_SERVERS: kafka
-          ZOOKEEPER_HOST: zoopkeeper
           SCHEMA_REGISTRY_HOST: schema-registry
           KAFKA_REST_PROXY_HOST: kafka-rest
       - name: lint

--- a/.github/workflows/run_checks.yaml
+++ b/.github/workflows/run_checks.yaml
@@ -11,7 +11,7 @@ jobs:
       options: --user 1001 # don't run as root
     services:
       kafka:
-        image: apache/kafka:3.7.0
+        image: apache/kafka:3.9.2
         env:
           CLUSTER_ID: 8L6g2nShT-eMCtK--X46sw
           KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
@@ -27,13 +27,13 @@ jobs:
           KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
           KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       schema-registry:
-        image: confluentinc/cp-schema-registry:7.6.0
+        image: confluentinc/cp-schema-registry:7.9.2
         env:
           SCHEMA_REGISTRY_HOST_NAME: schema-registry
           SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: kafka:9092
           SCHEMA_REGISTRY_LISTENERS: http://schema-registry:8081
       kafka-rest:
-        image: confluentinc/cp-kafka-rest:7.6.0
+        image: confluentinc/cp-kafka-rest:7.9.2
         env:
           KAFKA_REST_BOOTSTRAP_SERVERS: kafka:9092
           KAFKA_REST_HOST_NAME: kafka-rest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Update Kafka to 3.7.0 (confluent 7.6.0)
+
 ### [0.9.12] - [2023-12-05]
 - Support for Foreign Key joins [#365](https://github.com/FundingCircle/jackdaw/pull/365) (Issue [#364])
 - add manifold and keep aleph in dev dependencies [#360](https://github.com/FundingCircle/jackdaw/pull/360). Users of test-machine will have to add aleph to the test deps in their app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- Update Kafka to 3.7.0 (confluent 7.6.0)
+- Update Kafka to 3.9.2 (confluent 7.9.2)
 
 ### [0.9.12] - [2023-12-05]
 - Support for Foreign Key joins [#365](https://github.com/FundingCircle/jackdaw/pull/365) (Issue [#364])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,37 @@
 version: '2'
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.6.0
-    hostname: zookeeper
-    container_name: zookeeper
-    ports:
-      - "2181:2181"
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-
   broker:
-    image: confluentinc/cp-server:7.6.0
+    image: apache/kafka:3.7.0
     hostname: broker
     container_name: broker
-    depends_on:
-      - zookeeper
     ports:
-      - "9092:9092"
       - "9101:9101"
+      - "9092:9092"
     logging:
       driver: none
     environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092"
+      KAFKA_NODE_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT_HOST://localhost:9092,PLAINTEXT://broker:29092'
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
+      KAFKA_LISTENERS: 'CONTROLLER://:29093,PLAINTEXT_HOST://:9092,PLAINTEXT://:29092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      CLUSTER_ID: '8L6g2nShT-eMCtK--X46sw'
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_CONFLUENT_LICENSE_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_CONFLUENT_BALANCER_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
       KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    healthcheck:
+      test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "broker:29092", "--list"]
+      interval: 5s
+      timeout: 3s
+      retries: 60
 
   schema-registry:
     image: confluentinc/cp-schema-registry:7.6.0
@@ -62,8 +59,7 @@ services:
     logging:
       driver: none
     environment:
-      KAFKA_REST_ZOOKEEPER_CONNECT: "zookeeper:2181"
       KAFKA_REST_BOOTSTRAP_SERVERS: "broker:29092"
-      KAFKA_REST_LISTENERS: http://0.0.0.0:8082
-      KAFKA_REST_SCHEMA_REGISTRY: http://schema-registry:8081
       KAFKA_REST_HOST_NAME: localhost
+      KAFKA_REST_LISTENERS: http://0.0.0.0:8082
+      KAFKA_REST_SCHEMA_REGISTRY_URL: http://schema-registry:8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.1.1
+    image: confluentinc/cp-zookeeper:7.6.0
     hostname: zookeeper
     container_name: zookeeper
     ports:
@@ -11,7 +11,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-server:6.1.1
+    image: confluentinc/cp-server:7.6.0
     hostname: broker
     container_name: broker
     depends_on:
@@ -37,7 +37,7 @@ services:
       KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:6.1.1
+    image: confluentinc/cp-schema-registry:7.6.0
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -52,7 +52,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   kafka-rest:
-    image: confluentinc/cp-kafka-rest:6.1.1
+    image: confluentinc/cp-kafka-rest:7.6.0
     hostname: kafka-rest
     container_name: kafka-rest
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
       KAFKA_JMX_PORT: 9101
       KAFKA_JMX_HOSTNAME: localhost
-      KAFKA_CONFLUENT_SCHEMA_REGISTRY_URL: http://schema-registry:8081
     healthcheck:
       test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "broker:29092", "--list"]
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '2'
 services:
   broker:
-    image: apache/kafka:3.7.0
+    image: apache/kafka:3.9.2
     hostname: broker
     container_name: broker
     ports:
@@ -33,7 +32,7 @@ services:
       retries: 60
 
   schema-registry:
-    image: confluentinc/cp-schema-registry:7.6.0
+    image: confluentinc/cp-schema-registry:7.9.2
     hostname: schema-registry
     container_name: schema-registry
     depends_on:
@@ -48,7 +47,7 @@ services:
       SCHEMA_REGISTRY_LISTENERS: http://0.0.0.0:8081
 
   kafka-rest:
-    image: confluentinc/cp-kafka-rest:7.6.0
+    image: confluentinc/cp-kafka-rest:7.9.2
     hostname: kafka-rest
     container_name: kafka-rest
     depends_on:

--- a/project.clj
+++ b/project.clj
@@ -17,13 +17,16 @@
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.
                  ;; See https://docs.confluent.io/current/release-notes.html
-                 [io.confluent/kafka-schema-registry-client "7.3.2"
-                  :exclusions [com.fasterxml.jackson.core/jackson-databind]]
-                 [io.confluent/kafka-avro-serializer "7.3.2"]
-                 [io.confluent/kafka-json-schema-serializer "7.3.2"]
-                 [org.apache.kafka/kafka-clients "3.3.2"]
-                 [org.apache.kafka/kafka-streams "3.3.2"]
-                 [org.apache.kafka/kafka-streams-test-utils "3.3.2"]
+                 [io.confluent/kafka-json-schema-serializer "7.6.0" :exclusions [org.apache.kafka/kafka-clients]]
+                 [io.confluent/kafka-avro-serializer "7.6.0" :exclusions [org.apache.kafka/kafka-clients
+                                                                           org.apache.commons/commons-compress]]
+                 [io.confluent/kafka-schema-registry-client "7.6.0" :exclusions [org.apache.kafka/kafka-clients
+                                                                                 com.fasterxml.jackson.core/jackson-databind
+                                                                                 org.apache.commons/commons-compress]]
+
+                 [org.apache.kafka/kafka-clients "3.7.0"]
+                 [org.apache.kafka/kafka-streams "3.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [org.apache.kafka/kafka-streams-test-utils "3.7.0"]
 
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/java.data "1.0.95"]
@@ -31,7 +34,7 @@
                  [org.clojure/data.fressian "1.0.0"]
                  [org.clojure/tools.logging "1.2.4"]
                  [org.clojure/core.cache "1.0.225"]
-                 [metosin/jsonista "0.3.7"]]
+                 [metosin/jsonista "0.3.8"]]
 
   :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.edn2 jackdaw.serdes.fressian jackdaw.serdes.fn-impl]
@@ -76,11 +79,11 @@
               :resource-paths ["test/resources"]
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "1.0"]
-                             [aleph/aleph "0.6.1"]
-                             [org.apache.kafka/kafka-streams-test-utils "3.3.2"]
-                             [org.apache.kafka/kafka-clients "3.3.2" :classifier "test"]
+                             [aleph/aleph "0.6.3"]
+                             [org.apache.kafka/kafka-streams-test-utils "3.7.0"]
+                             [org.apache.kafka/kafka-clients "3.7.0" :classifier "test"]
                              [org.clojure/test.check "1.1.1"]
-                             [org.apache.kafka/kafka_2.13 "3.3.2"]
+                             [org.apache.kafka/kafka_2.13 "3.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                              [lambdaisland/kaocha "1.80.1274"]
                              [lambdaisland/kaocha-cloverage "1.1.89"]
                              [lambdaisland/kaocha-junit-xml "1.17.101"]]}

--- a/project.clj
+++ b/project.clj
@@ -17,16 +17,16 @@
                  ;; Confluent does paired releases with Kafka, this should tie
                  ;; off with the kafka version.
                  ;; See https://docs.confluent.io/current/release-notes.html
-                 [io.confluent/kafka-json-schema-serializer "7.6.0" :exclusions [org.apache.kafka/kafka-clients]]
-                 [io.confluent/kafka-avro-serializer "7.6.0" :exclusions [org.apache.kafka/kafka-clients
+                 [io.confluent/kafka-json-schema-serializer "7.9.2" :exclusions [org.apache.kafka/kafka-clients]]
+                 [io.confluent/kafka-avro-serializer "7.9.2" :exclusions [org.apache.kafka/kafka-clients
                                                                            org.apache.commons/commons-compress]]
-                 [io.confluent/kafka-schema-registry-client "7.6.0" :exclusions [org.apache.kafka/kafka-clients
+                 [io.confluent/kafka-schema-registry-client "7.9.2" :exclusions [org.apache.kafka/kafka-clients
                                                                                  com.fasterxml.jackson.core/jackson-databind
                                                                                  org.apache.commons/commons-compress]]
 
-                 [org.apache.kafka/kafka-clients "3.7.0"]
-                 [org.apache.kafka/kafka-streams "3.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [org.apache.kafka/kafka-streams-test-utils "3.7.0"]
+                 [org.apache.kafka/kafka-clients "3.9.1"]
+                 [org.apache.kafka/kafka-streams "3.9.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [org.apache.kafka/kafka-streams-test-utils "3.9.1"]
 
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/java.data "1.0.95"]
@@ -80,10 +80,10 @@
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "1.0"]
                              [aleph/aleph "0.6.3"]
-                             [org.apache.kafka/kafka-streams-test-utils "3.7.0"]
-                             [org.apache.kafka/kafka-clients "3.7.0" :classifier "test"]
+                             [org.apache.kafka/kafka-streams-test-utils "3.9.1"]
+                             [org.apache.kafka/kafka-clients "3.9.1" :classifier "test"]
                              [org.clojure/test.check "1.1.1"]
-                             [org.apache.kafka/kafka_2.13 "3.7.0" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                             [org.apache.kafka/kafka_2.13 "3.9.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                              [lambdaisland/kaocha "1.80.1274"]
                              [lambdaisland/kaocha-cloverage "1.1.89"]
                              [lambdaisland/kaocha-junit-xml "1.17.101"]]}

--- a/project.clj
+++ b/project.clj
@@ -80,7 +80,6 @@
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "1.0"]
                              [aleph/aleph "0.6.3"]
-                             [org.apache.kafka/kafka-streams-test-utils "3.9.2"]
                              [org.apache.kafka/kafka-clients "3.9.2" :classifier "test"]
                              [org.clojure/test.check "1.1.1"]
                              [org.apache.kafka/kafka_2.13 "3.9.2" :exclusions [com.fasterxml.jackson.core/jackson-core]]

--- a/project.clj
+++ b/project.clj
@@ -24,9 +24,9 @@
                                                                                  com.fasterxml.jackson.core/jackson-databind
                                                                                  org.apache.commons/commons-compress]]
 
-                 [org.apache.kafka/kafka-clients "3.9.1"]
-                 [org.apache.kafka/kafka-streams "3.9.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
-                 [org.apache.kafka/kafka-streams-test-utils "3.9.1"]
+                 [org.apache.kafka/kafka-clients "3.9.2"]
+                 [org.apache.kafka/kafka-streams "3.9.2" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 [org.apache.kafka/kafka-streams-test-utils "3.9.2"]
 
                  [org.clojure/clojure "1.11.1" :scope "provided"]
                  [org.clojure/java.data "1.0.95"]
@@ -80,10 +80,10 @@
               :injections [(require 'io.aviso.logging.setup)]
               :dependencies [[io.aviso/logging "1.0"]
                              [aleph/aleph "0.6.3"]
-                             [org.apache.kafka/kafka-streams-test-utils "3.9.1"]
-                             [org.apache.kafka/kafka-clients "3.9.1" :classifier "test"]
+                             [org.apache.kafka/kafka-streams-test-utils "3.9.2"]
+                             [org.apache.kafka/kafka-clients "3.9.2" :classifier "test"]
                              [org.clojure/test.check "1.1.1"]
-                             [org.apache.kafka/kafka_2.13 "3.9.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                             [org.apache.kafka/kafka_2.13 "3.9.2" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                              [lambdaisland/kaocha "1.80.1274"]
                              [lambdaisland/kaocha-cloverage "1.1.89"]
                              [lambdaisland/kaocha-junit-xml "1.17.101"]]}

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :repositories [["confluent" {:url "https://packages.confluent.io/maven/"}]
                  ["mulesoft" {:url "https://repository.mulesoft.org/nexus/content/repositories/public/"}]]
 
-  :dependencies [[manifold/manifold "0.4.0"]
+  :dependencies [[manifold/manifold "0.5.0"]
                  [danlentz/clj-uuid "0.1.9"
                   :exclusions [primitive-math]]
 
@@ -29,12 +29,12 @@
                  [org.apache.kafka/kafka-streams-test-utils "3.9.2"]
 
                  [org.clojure/clojure "1.11.1" :scope "provided"]
-                 [org.clojure/java.data "1.0.95"]
+                 [org.clojure/java.data "1.4.120"]
                  [org.clojure/data.json "2.4.0"]
-                 [org.clojure/data.fressian "1.0.0"]
-                 [org.clojure/tools.logging "1.2.4"]
-                 [org.clojure/core.cache "1.0.225"]
-                 [metosin/jsonista "0.3.8"]]
+                 [org.clojure/data.fressian "1.1.1"]
+                 [org.clojure/tools.logging "1.3.1"]
+                 [org.clojure/core.cache "1.2.263"]
+                 [metosin/jsonista "0.3.14"]]
 
   :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :aot [jackdaw.serdes.edn2 jackdaw.serdes.fressian jackdaw.serdes.fn-impl]


### PR DESCRIPTION
A deps update before 4.x

# Checklist
- Update deps
- use smaller apache kafka image for the broker
- remove zookeeper from docker
- 
- [X] tests
- [X] updated [CHANGELOG](../CHANGELOG.md) (the "unreleased" section)
