### PR TITLE
EE-249: Add Dependabot configuration 

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,65 @@
+version: 2
+updates:
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "docker-compose"
+    groups:
+      docker-compose-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "docker-compose"
+    directory: "/examples/rolldice"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "docker-compose"
+    groups:
+      docker-compose-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 3
+    pull-request-branch-name:
+      separator: "-"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "github-actions"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds `.github/dependabot.yaml` to enable automated dependency update PRs.

---
Blocked by / tracked in: **EE-589** (org ruleset requires `fc-checks/jira-issue` but the app never posts → check stuck in "Expected").